### PR TITLE
Fix liquidity and requiredProceeds computation flipping the prices according to token direction when it's already been flipped

### DIFF
--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -221,17 +221,11 @@ contract Doppler is BaseHook {
         uint128 liquidity;
         uint256 requiredProceeds;
         if (totalTokensSold_ != 0) {
-            if (isToken0) {
-                // TODO: Check max liquidity per tick
-                //       Should we spread liquidity across multiple ticks if necessary?
-                liquidity = LiquidityAmounts.getLiquidityForAmount0(sqrtPriceLower, sqrtPriceNext, totalTokensSold_);
-                // TODO: Should we be rounding up here?
-                requiredProceeds = SqrtPriceMath.getAmount1Delta(sqrtPriceLower, sqrtPriceNext, liquidity, true);
-            } else {
-                liquidity = LiquidityAmounts.getLiquidityForAmount1(sqrtPriceNext, sqrtPriceUpper, totalTokensSold_);
-                // TODO: Should we be rounding up here?
-                requiredProceeds = SqrtPriceMath.getAmount0Delta(sqrtPriceNext, sqrtPriceUpper, liquidity, true);
-            }
+            // TODO: Check max liquidity per tick
+            //       Should we spread liquidity across multiple ticks if necessary?
+            liquidity = LiquidityAmounts.getLiquidityForAmount0(sqrtPriceLower, sqrtPriceNext, totalTokensSold_);
+            // TODO: Should we be rounding up here?
+            requiredProceeds = SqrtPriceMath.getAmount1Delta(sqrtPriceLower, sqrtPriceNext, liquidity, true);
         }
 
         int24 lowerSlugTickUpper = tickLower;


### PR DESCRIPTION
We retrieve sqrtPriceLower and sqrtPriceUpper according to the ticks from `_getTicksBasedOnState` then swap the lower price between them according to whether the asset is token0. But `_getTicksBasedOnState` is already token agnostic and computes the tickUpper as not necessarily being the greater tick but rather being the tick that corresponds to a higher asset price