### PR TITLE
Revert before start time

### DIFF
--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -89,9 +89,9 @@ contract Doppler is BaseHook {
         onlyPoolManager
         returns (bytes4, BeforeSwapDelta, uint24)
     {
+        if (block.timestamp < startingTime) revert BeforeStartTime();
         if (
-            block.timestamp < startingTime
-                || ((block.timestamp - startingTime) / epochLength + 1) <= uint256(state.lastEpoch)
+            ((block.timestamp - startingTime) / epochLength + 1) <= uint256(state.lastEpoch)
         ) {
             // TODO: consider whether there's any logic we wanna run regardless
 
@@ -535,3 +535,4 @@ contract Doppler is BaseHook {
 }
 
 error Unauthorized();
+error BeforeStartTime();

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -62,7 +62,7 @@ library Debug {
         int24 startTick,
         int24 endTick,
         uint256 epochLength,
-        uint256 gamma,
+        int24 gamma,
         bool isToken0
     ) internal {
         uint256 currentTime = block.timestamp;

--- a/test/Doppler.t.sol
+++ b/test/Doppler.t.sol
@@ -111,37 +111,20 @@ contract DopplerTest is Test, Deployers {
     //                         beforeSwap Unit Tests
     // =========================================================================
 
-    function testBeforeSwap_DoesNotRebalanceBeforeStartTime() public {
+    function testBeforeSwap_RevertsBeforeStartTime() public {
         for (uint256 i; i < dopplers.length; ++i) {
             vm.warp(dopplers[i].getStartingTime() - 1); // 1 second before the start time
 
             PoolKey memory poolKey = keys[i];
 
             vm.prank(address(manager));
+            vm.expectRevert(BeforeStartTime.selector);
             (bytes4 selector, BeforeSwapDelta delta, uint24 fee) = dopplers[i].beforeSwap(
                 address(this),
                 poolKey,
                 IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100e18, sqrtPriceLimitX96: SQRT_RATIO_2_1}),
                 ""
             );
-
-            assertEq(selector, BaseHook.beforeSwap.selector);
-            assertEq(BeforeSwapDelta.unwrap(delta), 0);
-            assertEq(fee, 0);
-
-            (
-                uint40 lastEpoch,
-                int256 tickAccumulator,
-                uint256 totalTokensSold,
-                uint256 totalProceeds,
-                uint256 totalTokensSoldLastEpoch
-            ) = dopplers[i].state();
-
-            assertEq(lastEpoch, 0);
-            assertEq(tickAccumulator, 0);
-            assertEq(totalTokensSold, 0);
-            assertEq(totalProceeds, 0);
-            assertEq(totalTokensSoldLastEpoch, 0);
         }
     }
 
@@ -574,3 +557,4 @@ contract DopplerTest is Test, Deployers {
 }
 
 error Unauthorized();
+error BeforeStartTime();


### PR DESCRIPTION
It's important that we prevent swaps before the start time because since there's no liquidity, an attacker could swap 0 amounts to arbitrarily set the price which will manipulate the liquidity positions.

This also fixes the incorrect type provided for gamma in BaseTest which was causing a compilation error