### PR TITLE
Always align currentTick to nearest tickSpacing

### DIFF
--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -211,8 +211,7 @@ contract Doppler is BaseHook {
             state.tickAccumulator = newAccumulator;
         }
 
-        // TODO: Safe to only update currentTick if accumulatorDelta is a multiple of tickSpacing?
-        //       Or do we need to accumulate this difference over time to ensure it gets applied later?
+        // TODO: Do we need to accumulate this difference over time to ensure it gets applied later?
         //       e.g. if accumulatorDelta is 4e18 for two epochs in a row, should we bump up by a tickSpacing
         //       after the second epoch, or only adjust on significant epochs?
         //       Maybe this is only necessary for the oversold case anyway?


### PR DESCRIPTION
It's important that we always align the currentTick to the nearest tickSpacing because we may use it to set the upper tick of the lower bound, which needs to be aligned according to the tickSpacing. This change also allows the accumulatorDelta to move the currentTick up or down a tickSpacing even if the accumulatorDelta itself is less than a full tickSpacing