### PR TITLE
CVF-1, CVF-23

### DIFF
--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -112,7 +112,10 @@ contract Doppler is BaseHook {
         if (_startingTime >= _endingTime) revert InvalidTimeRange();
         // Inconsistent gamma, epochs must be long enough such that the upperSlug is at least 1 tick
         // TODO: Consider whether this should check if the left side is less than tickSpacing
-        if (FullMath.mulDiv(FullMath.mulDiv(_epochLength, 1e18, timeDelta), uint256(int256(_gamma)), 1e18) == 0) {
+        if (
+            _gamma <= 0
+                || FullMath.mulDiv(FullMath.mulDiv(_epochLength, 1e18, timeDelta), uint256(int256(_gamma)), 1e18) == 0
+        ) {
             revert InvalidGamma();
         }
         // _endingTime - startingTime must be divisible by epochLength


### PR DESCRIPTION
> Unchecked underflow and overflow is possible when converting types.

> This could be simplified as:
> `if (FullMath.mulDiv(_epochLength, uint256(int256(_gamma)), timeDelta) == 0)`