### PR TITLE
CVF-8

### DIFF
--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -107,9 +107,9 @@ contract Doppler is BaseHook {
         if (_poolKey.tickSpacing > MAX_TICK_SPACING) revert InvalidTickSpacing();
 
         /* Time checks */
-        uint256 timeDelta = _endingTime - _startingTime;
         // Starting time must be less than ending time
         if (_startingTime >= _endingTime) revert InvalidTimeRange();
+        uint256 timeDelta = _endingTime - _startingTime;
         // Inconsistent gamma, epochs must be long enough such that the upperSlug is at least 1 tick
         // TODO: Consider whether this should check if the left side is less than tickSpacing
         if (int256(FullMath.mulDiv(FullMath.mulDiv(_epochLength, 1e18, timeDelta), uint256(int256(_gamma)), 1e18)) == 0)


### PR DESCRIPTION
> In case the starting time is greater than the ending time, the subtraction will underflow and cause revert without any meaningful error message.