### PR TITLE
Allow user-specified v4 `fee` and `tickSpacing`

### DIFF
--- a/src/UniswapV4Initializer.sol
+++ b/src/UniswapV4Initializer.sol
@@ -98,8 +98,10 @@ contract UniswapV4Initializer is IPoolInitializer {
             revert OnlyAirlock();
         }
 
-        (uint160 sqrtPriceX96,,,,,,,,, bool isToken0,) =
-            abi.decode(data, (uint160, uint256, uint256, uint256, uint256, int24, int24, uint256, int24, bool, uint256));
+        (uint160 sqrtPriceX96,,,,,,,,, bool isToken0,, uint24 fee, int24 tickSpacing) = abi.decode(
+            data,
+            (uint160, uint256, uint256, uint256, uint256, int24, int24, uint256, int24, bool, uint256, uint24, int24)
+        );
 
         Doppler doppler = deployer.deploy(numTokensToSell, salt, data);
 
@@ -111,8 +113,8 @@ contract UniswapV4Initializer is IPoolInitializer {
             currency0: isToken0 ? Currency.wrap(asset) : Currency.wrap(numeraire),
             currency1: isToken0 ? Currency.wrap(numeraire) : Currency.wrap(asset),
             hooks: IHooks(doppler),
-            fee: 3000,
-            tickSpacing: 8
+            fee: fee,
+            tickSpacing: tickSpacing
         });
 
         address(asset).safeTransferFrom(address(airlock), address(doppler), numTokensToSell);

--- a/test/unit/Airlock.t.sol
+++ b/test/unit/Airlock.t.sol
@@ -139,7 +139,9 @@ contract AirlockTest is Test, Deployers {
             DEFAULT_EPOCH_LENGTH,
             DEFAULT_GAMMA,
             false,
-            DEFAULT_PD_SLUGS
+            DEFAULT_PD_SLUGS,
+            DEFAULT_FEE,
+            DEFAULT_TICK_SPACING
         );
 
         (bytes32 salt, address hook, address asset) = mineV4(

--- a/test/unit/UniswapV4Initializer.t.sol
+++ b/test/unit/UniswapV4Initializer.t.sol
@@ -19,6 +19,14 @@ import {
     UNISWAP_V2_ROUTER_UNICHAIN_SEPOLIA
 } from "test/shared/Addresses.sol";
 import { mineV4, MineV4Params } from "test/shared/AirlockMiner.sol";
+import { Currency, CurrencyLibrary } from "@v4-core/types/Currency.sol";
+import { TickMath } from "@v4-core/libraries/TickMath.sol";
+import { PoolKey } from "@v4-core/types/PoolKey.sol";
+import { IHooks } from "@v4-core/interfaces/IHooks.sol";
+import { StateLibrary } from "@v4-core/libraries/StateLibrary.sol";
+import { IPoolManager } from "@v4-core/interfaces/IPoolManager.sol";
+import { MAX_TICK_SPACING } from "src/Doppler.sol";
+import { DopplerTickLibrary } from "../util/DopplerTickLibrary.sol";
 
 uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 100_000e18;
 uint256 constant DEFAULT_MINIMUM_PROCEEDS = 100e18;
@@ -28,8 +36,7 @@ uint256 constant DEFAULT_ENDING_TIME = 2 days;
 int24 constant DEFAULT_GAMMA = 800;
 uint256 constant DEFAULT_EPOCH_LENGTH = 400 seconds;
 
-// default to feeless case for now
-uint24 constant DEFAULT_FEE = 0;
+uint24 constant DEFAULT_FEE = 3000;
 int24 constant DEFAULT_TICK_SPACING = 8;
 uint256 constant DEFAULT_NUM_PD_SLUGS = 3;
 
@@ -55,6 +62,8 @@ struct DopplerConfig {
 }
 
 contract UniswapV4InitializerTest is Test, Deployers {
+    using StateLibrary for IPoolManager;
+
     UniswapV4Initializer public initializer;
     DopplerDeployer public deployer;
     Airlock public airlock;
@@ -107,7 +116,7 @@ contract UniswapV4InitializerTest is Test, Deployers {
             numPDSlugs: DEFAULT_NUM_PD_SLUGS
         });
 
-        address numeraire = address(0);
+        address numeraire = Currency.unwrap(CurrencyLibrary.ADDRESS_ZERO);
 
         bytes memory tokenFactoryData =
             abi.encode("Best Token", "BEST", 1e18, 365 days, new address[](0), new uint256[](0));
@@ -126,7 +135,9 @@ contract UniswapV4InitializerTest is Test, Deployers {
             config.epochLength,
             config.gamma,
             false, // isToken0 will always be false using native token
-            config.numPDSlugs
+            config.numPDSlugs,
+            config.fee,
+            config.tickSpacing
         );
 
         (bytes32 salt, address hook, address token) = mineV4(
@@ -165,5 +176,97 @@ contract UniswapV4InitializerTest is Test, Deployers {
 
         assertEq(pool, hook, "Wrong pool");
         assertEq(asset, token, "Wrong asset");
+    }
+
+    function test_fuzz_v4initialize_fee_tickSpacing(uint24 fee, int24 tickSpacing) public {
+        fee = uint24(bound(fee, 0, 1_000_000)); // 0.00% to 100%
+        tickSpacing = int24(bound(tickSpacing, 1, MAX_TICK_SPACING - 1));
+        int24 gamma = (DEFAULT_GAMMA / tickSpacing) * tickSpacing; // align gamma with tickSpacing, rounding down
+
+        DopplerConfig memory config = DopplerConfig({
+            numTokensToSell: DEFAULT_NUM_TOKENS_TO_SELL,
+            minimumProceeds: DEFAULT_MINIMUM_PROCEEDS,
+            maximumProceeds: DEFAULT_MAXIMUM_PROCEEDS,
+            startingTime: block.timestamp + DEFAULT_STARTING_TIME,
+            endingTime: block.timestamp + DEFAULT_ENDING_TIME,
+            gamma: gamma,
+            epochLength: DEFAULT_EPOCH_LENGTH,
+            fee: fee,
+            tickSpacing: tickSpacing,
+            numPDSlugs: DEFAULT_NUM_PD_SLUGS
+        });
+
+        address numeraire = Currency.unwrap(CurrencyLibrary.ADDRESS_ZERO);
+        bool isToken0 = false; // numeraire native Ether is address(0) so asset is always token1
+
+        bytes memory tokenFactoryData =
+            abi.encode("Best Token", "BEST", 1e18, 365 days, new address[](0), new uint256[](0));
+        bytes memory governanceFactoryData = abi.encode("Best Token");
+
+        int24 startTick = DopplerTickLibrary.alignComputedTickWithTickSpacing(isToken0, DEFAULT_START_TICK, tickSpacing);
+        uint160 sqrtPrice = TickMath.getSqrtPriceAtTick(startTick);
+        int24 endTick = DopplerTickLibrary.alignComputedTickWithTickSpacing(isToken0, DEFAULT_END_TICK, tickSpacing);
+
+        bytes memory poolInitializerData = abi.encode(
+            sqrtPrice,
+            config.minimumProceeds,
+            config.maximumProceeds,
+            config.startingTime,
+            config.endingTime,
+            startTick,
+            endTick,
+            config.epochLength,
+            config.gamma,
+            isToken0,
+            config.numPDSlugs,
+            config.fee,
+            config.tickSpacing
+        );
+
+        (bytes32 salt, address hook, address token) = mineV4(
+            MineV4Params(
+                address(airlock),
+                address(manager),
+                config.numTokensToSell,
+                config.numTokensToSell,
+                numeraire,
+                ITokenFactory(address(tokenFactory)),
+                tokenFactoryData,
+                initializer,
+                poolInitializerData
+            )
+        );
+
+        (address asset, address pool,,,) = airlock.create(
+            CreateParams(
+                config.numTokensToSell,
+                config.numTokensToSell,
+                numeraire,
+                tokenFactory,
+                tokenFactoryData,
+                governanceFactory,
+                governanceFactoryData,
+                initializer,
+                poolInitializerData,
+                migrator,
+                "",
+                address(this),
+                salt
+            )
+        );
+
+        assertEq(pool, hook, "Wrong pool");
+        assertEq(asset, token, "Wrong asset");
+
+        // confirm the pool is initialized
+        PoolKey memory poolKey = PoolKey({
+            currency0: CurrencyLibrary.ADDRESS_ZERO,
+            currency1: Currency.wrap(address(asset)),
+            fee: fee,
+            tickSpacing: tickSpacing,
+            hooks: IHooks(hook)
+        });
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(poolKey.toId());
+        assertEq(sqrtPriceX96, sqrtPrice, "Wrong starting price");
     }
 }

--- a/test/unit/UniswapV4Initializer.t.sol
+++ b/test/unit/UniswapV4Initializer.t.sol
@@ -180,7 +180,7 @@ contract UniswapV4InitializerTest is Test, Deployers {
 
     function test_fuzz_v4initialize_fee_tickSpacing(uint24 fee, int24 tickSpacing) public {
         fee = uint24(bound(fee, 0, 1_000_000)); // 0.00% to 100%
-        tickSpacing = int24(bound(tickSpacing, 1, MAX_TICK_SPACING - 1));
+        tickSpacing = int24(bound(tickSpacing, 1, MAX_TICK_SPACING));
         int24 gamma = (DEFAULT_GAMMA / tickSpacing) * tickSpacing; // align gamma with tickSpacing, rounding down
 
         DopplerConfig memory config = DopplerConfig({

--- a/test/util/DopplerTickLibrary.sol
+++ b/test/util/DopplerTickLibrary.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+library DopplerTickLibrary {
+    /// @notice Aligns a given tick with the tickSpacing of the pool
+    ///         Rounds down according to the asset token denominated price
+    /// @dev Copied from Doppler.sol
+    /// @param tick The tick to align
+    /// @param tickSpacing The tick spacing of the pool
+    function alignComputedTickWithTickSpacing(
+        bool isToken0,
+        int24 tick,
+        int24 tickSpacing
+    ) internal pure returns (int24) {
+        if (isToken0) {
+            // Round down if isToken0
+            if (tick < 0) {
+                // If the tick is negative, we round up (negatively) the negative result to round down
+                return (tick - tickSpacing + 1) / tickSpacing * tickSpacing;
+            } else {
+                // Else if positive, we simply round down
+                return tick / tickSpacing * tickSpacing;
+            }
+        } else {
+            // Round up if isToken1
+            if (tick < 0) {
+                // If the tick is negative, we round down the negative result to round up
+                return tick / tickSpacing * tickSpacing;
+            } else {
+                // Else if positive, we simply round up
+                return (tick + tickSpacing - 1) / tickSpacing * tickSpacing;
+            }
+        }
+    }
+}


### PR DESCRIPTION
cantina 26

---

Auctions on v3 allow users to select v3's fee tiers (1 bip, 5 bip, 30 bips, 1%)

Previously, auctions on v4 were hard-coded to `fee = 0.30% and tickSpace = 8`

This PR adds additional parameters to `poolInitializerData` to allow asset creators to specify their fee on v4 auctions. (PoolManager enforces a valid of fee of [0, 100%])

---

Note: this is "part 1" PR, I want to follow up in a "part 2" PR where I separate `poolInitializerData` into `struct DopplerConstructorArgs` and `struct V4PoolInitializeArgs`