### PR TITLE
Fix/migrate fee calculations

### DIFF
--- a/test/integration/V3.t.sol
+++ b/test/integration/V3.t.sol
@@ -129,8 +129,6 @@ contract V3Test is Test {
 
         uint256 balancePool = DERC20(asset).balanceOf(pool);
 
-        console.log("balancePool", balancePool);
-
         (, int24 currentTick,,,,,) = IUniswapV3Pool(pool).slot0();
 
         uint160 priceLimit = TickMath.getSqrtPriceAtTick(isToken0 ? targetTick : targetTick);
@@ -180,5 +178,12 @@ contract V3Test is Test {
         // Allow for some dust
         assertApproxEqAbs(poolBalanceAssetAfter, 0, 1000, "Pool balance of asset is not 0");
         assertApproxEqAbs(poolBalanceWETHAfter, 0, 1000, "Pool balance of WETH is not 0");
+
+        // Asset fees are zero because swap was only done in one direction
+        assertEq(airlock.protocolFees(asset), 0, "Protocol fees are 0");
+        assertEq(airlock.integratorFees(address(this), asset), 0, "Integrator fees are 0");
+
+        assertGt(airlock.protocolFees(WETH_MAINNET), 0, "Protocol fees are 0");
+        assertGt(airlock.integratorFees(address(this), WETH_MAINNET), 0, "Integrator fees are 0");
     }
 }


### PR DESCRIPTION
Fixed an issue found in cantina contest where the protocol fee cut will be too large, causing `migrate()` to revert.