### PR TITLE
fuzz v3 -> v2 migrations

### DIFF
--- a/test/integration/V3.t.sol
+++ b/test/integration/V3.t.sol
@@ -326,8 +326,8 @@ contract V3Test is Test {
             ISwapRouter(UNISWAP_V3_ROUTER_MAINNET).exactInputSingle(swapParams);
         }
 
-        uint256 wethBalBeforeMigration = WETH(payable(WETH_MAINNET)).balanceOf(address(this));
-        uint256 assetBalBeforeMigration = DERC20(asset).balanceOf(address(this));
+        uint256 wethBalBeforeMigration = WETH(payable(WETH_MAINNET)).balanceOf(pool);
+        uint256 assetBalBeforeMigration = DERC20(asset).balanceOf(pool);
 
         (, currentTick,,,,,) = IUniswapV3Pool(pool).slot0();
         (,, int24 _tickLower, int24 _tickUpper,,,,,) = initializer.getState(pool);
@@ -344,7 +344,7 @@ contract V3Test is Test {
         }
 
         uint256 poolBalanceAssetAfter = DERC20(asset).balanceOf(pool);
-        uint256 poolBalanceWETHAfter = DERC20(WETH_MAINNET).balanceOf(pool);
+        uint256 poolBalanceWETHAfter = WETH(payable(WETH_MAINNET)).balanceOf(pool);
 
         // Allow for some dust
         assertApproxEqAbs(poolBalanceAssetAfter, 0, 1000, "Pool balance of asset is not 0");
@@ -378,7 +378,17 @@ contract V3Test is Test {
         uint256 wethV2 = uint256(isToken0 ? reserve1 : reserve0);
         uint256 assetV2 = uint256(isToken0 ? reserve0 : reserve1);
 
-        assertApproxEqRel(wethV2, wethBalBeforeMigration - numeraireProtocolAmount - numeraireIntegratorAmount, 0.01e18);
-        assertApproxEqRel(assetV2, assetBalBeforeMigration - assetProtocolAmount - assetIntegratorAmount, 0.01e18);
+        assertApproxEqRel(
+            wethV2,
+            wethBalBeforeMigration - numeraireProtocolAmount - numeraireIntegratorAmount,
+            0.01e18,
+            "unaccounted for WETH"
+        );
+        assertApproxEqRel(
+            assetV2,
+            assetBalBeforeMigration - assetProtocolAmount - assetIntegratorAmount,
+            0.01e18,
+            "unaccounted for asset"
+        );
     }
 }

--- a/test/integration/V3.t.sol
+++ b/test/integration/V3.t.sol
@@ -13,11 +13,12 @@ import {
     PoolAlreadyExited,
     OnlyPool,
     CallbackData,
-    InitData
+    InitData,
+    CannotMigrateInsufficientTick
 } from "src/UniswapV3Initializer.sol";
 import { SenderNotAirlock } from "src/base/ImmutableAirlock.sol";
 import { Airlock, ModuleState, CreateParams } from "src/Airlock.sol";
-import { UniswapV2Migrator, IUniswapV2Router02, IUniswapV2Factory } from "src/UniswapV2Migrator.sol";
+import { UniswapV2Migrator, IUniswapV2Router02, IUniswapV2Factory, IUniswapV2Pair } from "src/UniswapV2Migrator.sol";
 import { DERC20 } from "src/DERC20.sol";
 import { TokenFactory } from "src/TokenFactory.sol";
 import { GovernanceFactory } from "src/GovernanceFactory.sol";
@@ -28,6 +29,8 @@ import {
     UNISWAP_V2_FACTORY_MAINNET,
     UNISWAP_V2_ROUTER_MAINNET
 } from "test/shared/Addresses.sol";
+
+import "forge-std/console2.sol";
 
 int24 constant DEFAULT_LOWER_TICK = 167_520;
 int24 constant DEFAULT_UPPER_TICK = 200_040;
@@ -193,5 +196,189 @@ contract V3Test is Test {
 
         assertGt(airlock.protocolFees(WETH_MAINNET), 0, "Protocol fees are 0");
         assertGt(airlock.integratorFees(address(this), WETH_MAINNET), 0, "Integrator fees are 0");
+    }
+
+    /// @dev an absurdly monolithic fuzz test to ensure successful migrations
+    function test_fuzz_v3_lifecycle(
+        uint256 initialSupply,
+        uint16 numPositions,
+        uint256 maxShareToBeSold,
+        uint8 numSwaps,
+        uint256 zeroForOneSeed
+    ) public {
+        initialSupply = bound(initialSupply, 1000e18, 10_000_000_000e18);
+        numPositions = uint16(bound(numPositions, 1, 16));
+        maxShareToBeSold = bound(maxShareToBeSold, 0.01 ether, 0.9 ether); // 1% to 90%
+        numSwaps = uint8(bound(numSwaps, 1, 100));
+        zeroForOneSeed = bound(zeroForOneSeed, 0, 1e18);
+
+        bool isToken0;
+        string memory name = "Best Coin";
+        string memory symbol = "BEST";
+        bytes memory governanceData = abi.encode(name);
+        bytes memory tokenFactoryData = abi.encode(name, symbol, 0, 0, new address[](0), new uint256[](0), "");
+
+        // Compute the asset address that will be created
+        bytes32 salt = bytes32(0);
+        bytes memory creationCode = type(DERC20).creationCode;
+        bytes memory create2Args = abi.encode(
+            name,
+            symbol,
+            initialSupply,
+            address(airlock),
+            address(airlock),
+            0,
+            0,
+            new address[](0),
+            new uint256[](0),
+            ""
+        );
+        address predictedAsset = vm.computeCreate2Address(
+            salt, keccak256(abi.encodePacked(creationCode, create2Args)), address(tokenFactory)
+        );
+        isToken0 = predictedAsset < address(WETH_MAINNET);
+
+        int24 tickLower = isToken0 ? -DEFAULT_UPPER_TICK : DEFAULT_LOWER_TICK;
+        int24 tickUpper = isToken0 ? -DEFAULT_LOWER_TICK : DEFAULT_UPPER_TICK;
+        int24 targetTick = isToken0 ? -DEFAULT_LOWER_TICK : DEFAULT_LOWER_TICK;
+
+        bytes memory poolInitializerData = abi.encode(
+            InitData({
+                fee: 3000,
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                numPositions: numPositions,
+                maxShareToBeSold: maxShareToBeSold
+            })
+        );
+
+        (address asset, address pool,,,) = airlock.create(
+            CreateParams(
+                initialSupply,
+                initialSupply,
+                WETH_MAINNET,
+                tokenFactory,
+                tokenFactoryData,
+                governanceFactory,
+                governanceData,
+                initializer,
+                poolInitializerData,
+                uniswapV2LiquidityMigrator,
+                "",
+                address(this),
+                salt
+            )
+        );
+
+        assertEq(asset, predictedAsset, "Predicted asset address doesn't match actual");
+
+        deal(address(this), 100_000_000 ether);
+        WETH(payable(WETH_MAINNET)).deposit{ value: 100_000_000 ether }();
+        WETH(payable(WETH_MAINNET)).approve(UNISWAP_V3_ROUTER_MAINNET, type(uint256).max);
+        DERC20(asset).approve(UNISWAP_V3_ROUTER_MAINNET, type(uint256).max);
+
+        // TODO: assert pool balance
+        // uint256 balancePool = DERC20(asset).balanceOf(pool);
+
+        // assert the starting price before swaps
+        (, int24 currentTick,,,,,) = IUniswapV3Pool(pool).slot0();
+        assertEq(currentTick, isToken0 ? tickLower : tickUpper);
+
+        // buy some asset to randomly trade against
+        uint160 priceLimit = TickMath.getSqrtPriceAtTick(targetTick);
+        uint256 amountOut = ISwapRouter(UNISWAP_V3_ROUTER_MAINNET).exactInputSingle(
+            ISwapRouter.ExactInputSingleParams({
+                tokenIn: WETH_MAINNET,
+                tokenOut: address(asset),
+                fee: 3000,
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: 1 ether,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: priceLimit
+            })
+        );
+        assertEq(amountOut, DERC20(asset).balanceOf(address(this)));
+
+        // perform a bunch of random swaps
+        bool zeroForOne;
+        uint256 amountIn;
+        address tokenIn;
+        ISwapRouter.ExactInputSingleParams memory swapParams;
+        for (uint8 i; i < numSwaps; i++) {
+            zeroForOne = uint256(keccak256(abi.encodePacked(zeroForOneSeed + i))) % 2 == 0;
+
+            tokenIn = ((zeroForOne && isToken0) || (!zeroForOne && !isToken0)) ? asset : WETH_MAINNET;
+
+            amountIn = tokenIn == asset ? DERC20(asset).balanceOf(address(this)) / 10 : 1 ether;
+
+            swapParams = ISwapRouter.ExactInputSingleParams({
+                tokenIn: tokenIn,
+                tokenOut: tokenIn == WETH_MAINNET ? asset : WETH_MAINNET,
+                fee: 3000,
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: amountIn,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+            });
+
+            ISwapRouter(UNISWAP_V3_ROUTER_MAINNET).exactInputSingle(swapParams);
+        }
+
+        uint256 wethBalBeforeMigration = WETH(payable(WETH_MAINNET)).balanceOf(address(this));
+        uint256 assetBalBeforeMigration = DERC20(asset).balanceOf(address(this));
+
+        (, currentTick,,,,,) = IUniswapV3Pool(pool).slot0();
+        (,, int24 _tickLower, int24 _tickUpper,,,,,) = initializer.getState(pool);
+        console2.log(currentTick);
+        console2.log(_tickLower);
+        console2.log(_tickUpper);
+        int24 farTick = isToken0 ? _tickUpper : _tickLower;
+        if ((isToken0 && currentTick < farTick) || (!isToken0 && currentTick > farTick)) {
+            vm.expectRevert(abi.encodeWithSelector(CannotMigrateInsufficientTick.selector, farTick, currentTick));
+            airlock.migrate(asset);
+            return;
+        } else {
+            airlock.migrate(asset);
+        }
+
+        uint256 poolBalanceAssetAfter = DERC20(asset).balanceOf(pool);
+        uint256 poolBalanceWETHAfter = DERC20(WETH_MAINNET).balanceOf(pool);
+
+        // Allow for some dust
+        assertApproxEqAbs(poolBalanceAssetAfter, 0, 1000, "Pool balance of asset is not 0");
+        assertApproxEqAbs(poolBalanceWETHAfter, 0, 1000, "Pool balance of WETH is not 0");
+
+        // collect fees
+        // TODO: figure out how to use DopplerFixtures._collectAllProtocolFees
+        uint256 numeraireProtocolAmount = airlock.protocolFees(WETH_MAINNET);
+        uint256 assetProtocolAmount = airlock.protocolFees(asset);
+        vm.startPrank(airlock.owner());
+        airlock.collectProtocolFees(address(this), WETH_MAINNET, numeraireProtocolAmount);
+        airlock.collectProtocolFees(address(this), asset, assetProtocolAmount);
+        vm.stopPrank();
+
+        address integrator = address(this);
+        uint256 numeraireIntegratorAmount = airlock.integratorFees(integrator, WETH_MAINNET);
+        uint256 assetIntegratorAmount = airlock.integratorFees(integrator, asset);
+        vm.startPrank(integrator);
+        airlock.collectIntegratorFees(address(this), WETH_MAINNET, numeraireIntegratorAmount);
+        airlock.collectIntegratorFees(address(this), asset, assetIntegratorAmount);
+        vm.stopPrank();
+
+        // airlock holds no dust
+        assertEq(DERC20(asset).balanceOf(address(airlock)), 0);
+        assertEq(WETH(payable(WETH_MAINNET)).balanceOf(address(airlock)), 0);
+
+        // liquidity migrated to V2
+        (,,,,,, address migrationPool,,,) = airlock.getAssetData(asset);
+        IUniswapV2Pair pair = IUniswapV2Pair(migrationPool);
+        (uint112 reserve0, uint112 reserve1,) = pair.getReserves();
+        uint256 wethV2 = uint256(isToken0 ? reserve1 : reserve0);
+        uint256 assetV2 = uint256(isToken0 ? reserve0 : reserve1);
+
+        assertApproxEqRel(wethV2, wethBalBeforeMigration - numeraireProtocolAmount - numeraireIntegratorAmount, 0.01e18);
+        assertApproxEqRel(assetV2, assetBalBeforeMigration - assetProtocolAmount - assetIntegratorAmount, 0.01e18);
     }
 }

--- a/test/integration/V3.t.sol
+++ b/test/integration/V3.t.sol
@@ -204,7 +204,8 @@ contract V3Test is Test {
         uint16 numPositions,
         uint256 maxShareToBeSold,
         uint8 numSwaps,
-        uint256 zeroForOneSeed
+        uint256 zeroForOneSeed,
+        bytes32 tokenSalt
     ) public {
         initialSupply = bound(initialSupply, 1000e18, 10_000_000_000e18);
         numPositions = uint16(bound(numPositions, 1, 16));
@@ -219,7 +220,6 @@ contract V3Test is Test {
         bytes memory tokenFactoryData = abi.encode(name, symbol, 0, 0, new address[](0), new uint256[](0), "");
 
         // Compute the asset address that will be created
-        bytes32 salt = bytes32(0);
         bytes memory creationCode = type(DERC20).creationCode;
         bytes memory create2Args = abi.encode(
             name,
@@ -234,7 +234,7 @@ contract V3Test is Test {
             ""
         );
         address predictedAsset = vm.computeCreate2Address(
-            salt, keccak256(abi.encodePacked(creationCode, create2Args)), address(tokenFactory)
+            tokenSalt, keccak256(abi.encodePacked(creationCode, create2Args)), address(tokenFactory)
         );
         isToken0 = predictedAsset < address(WETH_MAINNET);
 
@@ -266,7 +266,7 @@ contract V3Test is Test {
                 uniswapV2LiquidityMigrator,
                 "",
                 address(this),
-                salt
+                tokenSalt
             )
         );
 


### PR DESCRIPTION
fuzzed:
* initial supply
* number of positions
* max share to be sold
* number of swaps

---

1. creates a token sale on v3 with airlock
2. performs a random number of swaps in both directions
3. attempts migration
    * if the final tick is not crossed - expect a revert on migration
4. assuming a successful migration, assert:
    * pre-migration balances are predominantly in the v2 pair
    * in the case of discrepancy (i.e. price precision), excess balances are stored in the timelock