### PR TITLE
Cantina fix/redundant tick realignment

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,9 +12,11 @@ fs_permissions = [
 optimizer_runs = 0
 bytecode_hash = "none"
 optimizer = true
+gas_limit = "8000000000"
 
 [fuzz]
 max_test_rejects = 10000000
+runs = 32
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 

--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -343,10 +343,8 @@ contract Doppler is BaseHook {
                 });
 
                 // Include tickSpacing so we're at least at a higher price than the lower slug upper tick
-                uint160 sqrtPriceX96Next = TickMath.getSqrtPriceAtTick(
-                    _alignComputedTickWithTickSpacing(lowerSlug.tickUpper, key.tickSpacing)
-                        + (isToken0 ? key.tickSpacing : -key.tickSpacing)
-                );
+                uint160 sqrtPriceX96Next =
+                    TickMath.getSqrtPriceAtTick(lowerSlug.tickUpper + (isToken0 ? key.tickSpacing : -key.tickSpacing));
 
                 uint160 sqrtPriceX96 = TickMath.getSqrtPriceAtTick(currentTick);
                 _update(newPositions, sqrtPriceX96, sqrtPriceX96Next, key);


### PR DESCRIPTION
Closes https://github.com/whetstoneresearch/doppler/issues/318.

Looks like the failing test is caused by the AirlockMiner not finding a salt. I'm not sure why this is happening because the only change is in the `Doppler` contract itself. One potential explanation might be the different bytecode making it harder to find a salt.