### PR TITLE
fix: safely cast liquidityDelta

### DIFF
--- a/src/Doppler.sol
+++ b/src/Doppler.sol
@@ -1136,7 +1136,7 @@ contract Doppler is BaseHook {
                         IPoolManager.ModifyLiquidityParams({
                             tickLower: isToken0 ? position.tickLower : position.tickUpper,
                             tickUpper: isToken0 ? position.tickUpper : position.tickLower,
-                            liquidityDelta: -int128(position.liquidity),
+                            liquidityDelta: -position.liquidity.toInt128(),
                             salt: bytes32(uint256(position.salt))
                         }),
                         ""


### PR DESCRIPTION
Closes Cantina finding #87, not extremely likely to happen but I'd rather have a proper error just in case.