### PR TITLE
feat: custom allocation of LP tokens during migrate for v2 migrator

### DIFF
--- a/src/UniswapV2Migrator.sol
+++ b/src/UniswapV2Migrator.sol
@@ -55,7 +55,7 @@ contract UniswapV2Migrator is ILiquidityMigrator, ImmutableAirlock {
     /// @dev Liquidity to lock (% expressed in WAD)
     uint256 constant LP_TO_LOCK_WAD = 0.05 ether;
     /// @dev Maximum amount of liquidity that can be allocated to `lpAllocationRecipient` (% expressed in WAD)
-    uint256 constant MAX_LP_ALLOCATION_WAD = 0.1 ether;
+    uint256 constant MAX_LP_ALLOCATION_WAD = 0.02 ether;
 
     IUniswapV2Factory public immutable factory;
     IWETH public immutable weth;

--- a/src/extensions/CustomLPUniswapV2Locker.sol
+++ b/src/extensions/CustomLPUniswapV2Locker.sol
@@ -15,6 +15,11 @@ contract CustomLPUniswapV2Locker is UniswapV2Locker {
     using FixedPointMathLib for uint256;
     using FixedPointMathLib for uint160;
 
+    /// @dev Minimum lock up period for the custom LP allocation
+    uint256 public constant MIN_LOCK_PERIOD = 30 days;
+
+    error LessThanMinLockPeriod();
+
     /**
      * @param factory_ Address of the Uniswap V2 factory
      */
@@ -34,6 +39,7 @@ contract CustomLPUniswapV2Locker is UniswapV2Locker {
     function receiveAndLock(address pool, address recipient, uint32 lockPeriod) external {
         require(msg.sender == address(migrator), SenderNotMigrator());
         require(getState[pool].minUnlockDate == 0, PoolAlreadyInitialized());
+        require(lockPeriod >= MIN_LOCK_PERIOD, LessThanMinLockPeriod());
 
         uint256 balance = IUniswapV2Pair(pool).balanceOf(address(this));
         require(balance > 0, NoBalanceToLock());

--- a/src/extensions/CustomLPUniswapV2Locker.sol
+++ b/src/extensions/CustomLPUniswapV2Locker.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Ownable } from "@openzeppelin/access/Ownable.sol";
+import { SafeTransferLib, ERC20 } from "@solmate/utils/SafeTransferLib.sol";
+import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
+import { IUniswapV2Pair } from "src/interfaces/IUniswapV2Pair.sol";
+import { IUniswapV2Factory } from "src/interfaces/IUniswapV2Factory.sol";
+import { CustomLPUniswapV2Migrator } from "src/extensions/CustomLPUniswapV2Migrator.sol";
+import { UniswapV2Locker } from "src/UniswapV2Locker.sol";
+import { ImmutableAirlock } from "src/base/ImmutableAirlock.sol";
+
+contract CustomLPUniswapV2Locker is UniswapV2Locker {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using FixedPointMathLib for uint160;
+
+    /**
+     * @param factory_ Address of the Uniswap V2 factory
+     */
+    constructor(
+        address airlock_,
+        IUniswapV2Factory factory_,
+        CustomLPUniswapV2Migrator migrator_,
+        address owner_
+    ) UniswapV2Locker(airlock_, factory_, migrator_, owner_) { }
+
+    /**
+     * @notice Locks the LP tokens held by this contract with custom lock up period
+     * @param pool Address of the Uniswap V2 pool
+     * @param recipient Address of the recipient
+     * @param lockPeriod Duration of the lock period
+     */
+    function receiveAndLock(address pool, address recipient, uint32 lockPeriod) external {
+        require(msg.sender == address(migrator), SenderNotMigrator());
+        require(getState[pool].minUnlockDate == 0, PoolAlreadyInitialized());
+
+        uint256 balance = IUniswapV2Pair(pool).balanceOf(address(this));
+        require(balance > 0, NoBalanceToLock());
+
+        (uint112 reserve0, uint112 reserve1,) = IUniswapV2Pair(pool).getReserves();
+        uint256 supply = IUniswapV2Pair(pool).totalSupply();
+
+        uint112 amount0 = uint112((balance * reserve0) / supply);
+        uint112 amount1 = uint112((balance * reserve1) / supply);
+
+        getState[pool] = PoolState({
+            amount0: amount0,
+            amount1: amount1,
+            minUnlockDate: uint32(block.timestamp + lockPeriod),
+            recipient: recipient
+        });
+    }
+}

--- a/src/extensions/CustomLPUniswapV2Locker.sol
+++ b/src/extensions/CustomLPUniswapV2Locker.sol
@@ -15,13 +15,9 @@ contract CustomLPUniswapV2Locker is UniswapV2Locker {
     using FixedPointMathLib for uint256;
     using FixedPointMathLib for uint160;
 
-    /// @dev Minimum lock up period for the custom LP allocation
-    uint256 public constant MIN_LOCK_PERIOD = 30 days;
-
-    error LessThanMinLockPeriod();
-
     /**
      * @param factory_ Address of the Uniswap V2 factory
+     * @param migrator_ Address of the Uniswap V2 migrator
      */
     constructor(
         address airlock_,
@@ -39,7 +35,6 @@ contract CustomLPUniswapV2Locker is UniswapV2Locker {
     function receiveAndLock(address pool, address recipient, uint32 lockPeriod) external {
         require(msg.sender == address(migrator), SenderNotMigrator());
         require(getState[pool].minUnlockDate == 0, PoolAlreadyInitialized());
-        require(lockPeriod >= MIN_LOCK_PERIOD, LessThanMinLockPeriod());
 
         uint256 balance = IUniswapV2Pair(pool).balanceOf(address(this));
         require(balance > 0, NoBalanceToLock());

--- a/src/extensions/CustomLPUniswapV2Migrator.sol
+++ b/src/extensions/CustomLPUniswapV2Migrator.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import { SafeTransferLib, ERC20 } from "@solmate/utils/SafeTransferLib.sol";
@@ -11,72 +11,64 @@ import { IUniswapV2Router02 } from "src/interfaces/IUniswapV2Router02.sol";
 import { MigrationMath } from "src/libs/MigrationMath.sol";
 import { Airlock } from "src/Airlock.sol";
 import { UniswapV2Locker } from "src/UniswapV2Locker.sol";
+import { UniswapV2Migrator } from "src/UniswapV2Migrator.sol";
+import { CustomLPUniswapV2Locker } from "src/extensions/CustomLPUniswapV2Locker.sol";
 import { ImmutableAirlock } from "src/base/ImmutableAirlock.sol";
 
 /**
- * @author Whetstone Research
- * @notice Takes care of migrating liquidity into a Uniswap V2 pool
- * @custom:security-contact security@whetstone.cc
+ * @notice UniswapV2Migrator with custom LP allocation feature enabled
  */
-contract UniswapV2Migrator is ILiquidityMigrator, ImmutableAirlock {
+contract CustomLPUniswapV2Migrator is UniswapV2Migrator {
     using SafeTransferLib for ERC20;
 
-    IUniswapV2Factory public immutable factory;
-    IWETH public immutable weth;
-    UniswapV2Locker public immutable locker;
+    /// @dev Constant used to increase precision during calculations
+    uint256 constant WAD = 1 ether;
+    /// @dev Liquidity to lock (% expressed in WAD)
+    uint256 constant LP_TO_LOCK_WAD = 0.05 ether;
+    /// @dev Maximum amount of liquidity that can be allocated to `lpAllocationRecipient` (% expressed in WAD)
+    uint256 constant MAX_CUSTOM_LP_WAD = 0.02 ether;
 
-    receive() external payable onlyAirlock { }
+    CustomLPUniswapV2Locker public immutable customLPLocker;
 
-    /**
-     * @param factory_ Address of the Uniswap V2 factory
-     */
+    /// @dev Lock up period for the LP tokens allocated to `customLPRecipient`
+    uint32 public lockUpPeriod;
+    /// @dev Allow custom allocation of LP tokens other than `LP_TO_LOCK_WAD` (% expressed in WAD)
+    uint64 public customLPWad;
+    /// @dev Address of the recipient of the custom LP allocation
+    address public customLPRecipient;
+
+    error MaxCustomLPWadExceeded();
+    error RecipientNotEOA();
+    error InvalidInput();
+
     constructor(
         address airlock_,
         IUniswapV2Factory factory_,
         IUniswapV2Router02 router,
         address owner
-    ) ImmutableAirlock(airlock_) {
-        factory = factory_;
-        weth = IWETH(payable(router.WETH()));
-        locker = new UniswapV2Locker(airlock_, factory, this, owner);
+    ) UniswapV2Migrator(airlock_, factory_, router, owner) {
+        customLPLocker = new CustomLPUniswapV2Locker(airlock_, factory_, this, owner);
     }
 
-    function initialize(
+    function _initialize(
         address asset,
         address numeraire,
         bytes calldata liquidityMigratorData
-    ) external onlyAirlock returns (address) {
-        return _initialize(asset, numeraire, liquidityMigratorData);
-    }
+    ) internal override returns (address) {
+        if (liquidityMigratorData.length > 0) {
+            (uint64 customLPWad_, address customLPRecipient_, uint32 lockUpPeriod_) =
+                abi.decode(liquidityMigratorData, (uint64, address, uint32));
+            require(customLPWad_ > 0 && customLPRecipient_ != address(0), InvalidInput());
+            require(customLPWad_ <= MAX_CUSTOM_LP_WAD, MaxCustomLPWadExceeded());
+            // initially only allow EOA to receive the lp allocation
+            require(customLPRecipient_.code.length == 0, RecipientNotEOA());
 
-    /**
-     * @notice Migrates the liquidity into a Uniswap V2 pool
-     * @param sqrtPriceX96 Square root price of the pool as a Q64.96 value
-     * @param token0 Smaller address of the two tokens
-     * @param token1 Larger address of the two tokens
-     * @param recipient Address receiving the liquidity pool tokens
-     */
-    function migrate(
-        uint160 sqrtPriceX96,
-        address token0,
-        address token1,
-        address recipient
-    ) external payable onlyAirlock returns (uint256 liquidity) {
-        return _migrate(sqrtPriceX96, token0, token1, recipient);
-    }
-
-    function _initialize(address asset, address numeraire, bytes calldata) internal virtual returns (address) {
-        (address token0, address token1) = asset < numeraire ? (asset, numeraire) : (numeraire, asset);
-
-        if (token0 == address(0)) token0 = address(weth);
-
-        address pool = factory.getPair(token0, token1);
-
-        if (pool == address(0)) {
-            pool = factory.createPair(token0, token1);
+            customLPWad = customLPWad_;
+            customLPRecipient = customLPRecipient_;
+            lockUpPeriod = lockUpPeriod_;
         }
 
-        return pool;
+        return super._initialize(asset, numeraire, liquidityMigratorData);
     }
 
     function _migrate(
@@ -84,7 +76,7 @@ contract UniswapV2Migrator is ILiquidityMigrator, ImmutableAirlock {
         address token0,
         address token1,
         address recipient
-    ) internal virtual returns (uint256 liquidity) {
+    ) internal override returns (uint256 liquidity) {
         uint256 balance0;
         uint256 balance1 = ERC20(token1).balanceOf(address(this));
 
@@ -116,11 +108,17 @@ contract UniswapV2Migrator is ILiquidityMigrator, ImmutableAirlock {
         ERC20(token0).safeTransfer(pool, depositAmount0);
         ERC20(token1).safeTransfer(pool, depositAmount1);
 
+        // Custom LP allocation - 5% to locker, (n <= `MAX_CUSTOM_LP_WAD`)% to `customLPRecipient`, rest to timelock
         liquidity = IUniswapV2Pair(pool).mint(address(this));
-        uint256 liquidityToLock = liquidity / 20;
-        IUniswapV2Pair(pool).transfer(recipient, liquidity - liquidityToLock);
+        uint256 liquidityToLock = liquidity * LP_TO_LOCK_WAD / WAD;
+        uint256 customLiquidityToLock = liquidity * customLPWad / WAD;
+        uint256 liquidityToTransfer = liquidity - liquidityToLock - customLiquidityToLock;
+
+        IUniswapV2Pair(pool).transfer(recipient, liquidityToTransfer);
         IUniswapV2Pair(pool).transfer(address(locker), liquidityToLock);
+        IUniswapV2Pair(pool).transfer(address(customLPLocker), customLiquidityToLock);
         locker.receiveAndLock(pool, recipient);
+        customLPLocker.receiveAndLock(pool, customLPRecipient, lockUpPeriod);
 
         if (address(this).balance > 0) {
             SafeTransferLib.safeTransferETH(recipient, address(this).balance);

--- a/src/extensions/CustomLPUniswapV2Migrator.sol
+++ b/src/extensions/CustomLPUniswapV2Migrator.sol
@@ -26,7 +26,7 @@ contract CustomLPUniswapV2Migrator is UniswapV2Migrator {
     /// @dev Liquidity to lock (% expressed in WAD)
     uint256 constant LP_TO_LOCK_WAD = 0.05 ether;
     /// @dev Maximum amount of liquidity that can be allocated to `lpAllocationRecipient` (% expressed in WAD)
-    uint256 constant MAX_CUSTOM_LP_WAD = 0.02 ether;
+    uint256 constant MAX_CUSTOM_LP_WAD = 0.05 ether;
 
     CustomLPUniswapV2Locker public immutable customLPLocker;
 
@@ -108,7 +108,7 @@ contract CustomLPUniswapV2Migrator is UniswapV2Migrator {
         ERC20(token0).safeTransfer(pool, depositAmount0);
         ERC20(token1).safeTransfer(pool, depositAmount1);
 
-        // Custom LP allocation - 5% to locker, (n <= `MAX_CUSTOM_LP_WAD`)% to `customLPRecipient`, rest to timelock
+        // Custom LP allocation - 5% to locker, (n <= `MAX_CUSTOM_LP_WAD`)% to `customLPRecipient` after `lockUpPeriod`, rest to timelock
         liquidity = IUniswapV2Pair(pool).mint(address(this));
         uint256 liquidityToLock = liquidity * LP_TO_LOCK_WAD / WAD;
         uint256 customLiquidityToLock = liquidity * customLPWad / WAD;

--- a/src/interfaces/IUniswapV2Locker.sol
+++ b/src/interfaces/IUniswapV2Locker.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IUniswapV2Locker {
+    /**
+     * @notice State of a pool
+     * @param amount0 Reserve of token0
+     * @param amount1 Reserve of token1
+     * @param minUnlockDate Minimum unlock date
+     * @param recipient Address of the recipient
+     */
+    struct PoolState {
+        uint112 amount0;
+        uint112 amount1;
+        uint32 minUnlockDate;
+        address recipient;
+    }
+
+    /// @notice Thrown when the sender is not the migrator contract
+    error SenderNotMigrator();
+
+    /// @notice Thrown when trying to initialized a pool that was already initialized
+    error PoolAlreadyInitialized();
+
+    /// @notice Thrown when trying to exit a pool that was not initialized
+    error PoolNotInitialized();
+
+    /// @notice Thrown when the Locker contract doesn't hold any LP tokens
+    error NoBalanceToLock();
+
+    /// @notice Thrown when the minimum unlock date has not been reached
+    error MinUnlockDateNotReached();
+
+    function receiveAndLock(address pool, address recipient) external;
+
+    function claimFeesAndExit(
+        address pool
+    ) external;
+}

--- a/src/libs/MigrationMath.sol
+++ b/src/libs/MigrationMath.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.24;
+
+import { FullMath } from "@v4-core/libraries/FullMath.sol";
+
+library MigrationMath {
+    using FullMath for uint256;
+    using FullMath for uint160;
+
+    /**
+     * @dev Computes the amounts for an initial Uniswap V2 pool deposit.
+     * @param balance0 Current balance of token0
+     * @param balance1 Current balance of token1
+     * @param sqrtPriceX96 Square root price of the pool as a Q64.96 value
+     * @return depositAmount0 Amount of token0 to deposit
+     * @return depositAmount1 Amount of token1 to deposit
+     */
+    function computeDepositAmounts(
+        uint256 balance0,
+        uint256 balance1,
+        uint160 sqrtPriceX96
+    ) internal pure returns (uint256 depositAmount0, uint256 depositAmount1) {
+        // Stolen from https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/OracleLibrary.sol#L57
+        if (sqrtPriceX96 <= type(uint128).max) {
+            uint256 ratioX192 = uint256(sqrtPriceX96) * sqrtPriceX96;
+            depositAmount0 = balance1.mulDiv(1 << 192, ratioX192);
+            depositAmount1 = balance0.mulDiv(ratioX192, 1 << 192);
+        } else {
+            uint256 ratioX128 = sqrtPriceX96.mulDiv(sqrtPriceX96, 1 << 64);
+            depositAmount0 = balance1.mulDiv(1 << 128, ratioX128);
+            depositAmount1 = balance0.mulDiv(ratioX128, 1 << 128);
+        }
+    }
+}

--- a/test/unit/UniswapV2Migrator.t.sol
+++ b/test/unit/UniswapV2Migrator.t.sol
@@ -179,14 +179,14 @@ contract UniswapV2MigratorTest is Test {
     }
 
     function test_migrate_AllocateLPToContract_RevertsWhenLPRecipientIsNotEOA() public {
-        // TestERC20 token0 = new TestERC20(1000 ether);
-        // TestERC20 token1 = new TestERC20(1000 ether);
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
 
-        // address testContract = makeAddr("testContract");
-        // vm.etch(testContract, new bytes(1));
-        // bytes memory liquidityMigratorData = abi.encode(0.1 ether, testContract);
-        // vm.expectRevert(abi.encodeWithSelector(UniswapV2Migrator.LPRecipientNotEOA.selector));
-        // migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+        address testContract = makeAddr("testContract");
+        vm.etch(testContract, new bytes(1));
+        bytes memory liquidityMigratorData = abi.encode(0.1 ether, testContract);
+        vm.expectRevert(abi.encodeWithSelector(UniswapV2Migrator.LPRecipientNotEOA.selector));
+        migrator.initialize(address(token0), address(token1), liquidityMigratorData);
     }
 
     /*

--- a/test/unit/UniswapV2Migrator.t.sol
+++ b/test/unit/UniswapV2Migrator.t.sol
@@ -137,6 +137,58 @@ contract UniswapV2MigratorTest is Test {
         assertEq(lockedLiquidity, IUniswapV2Pair(pool).balanceOf(address(migrator.locker())), "Wrong locked liquidity");
     }
 
+    function test_migrate_AllocateLPToAlice_WhenLiquidityMigratorDataNotEmpty() public {
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
+        address alice = makeAddr("alice");
+
+        // allocate 10% LP to alice during migration
+        bytes memory liquidityMigratorData = abi.encode(0.1 ether, alice);
+        address pool = migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+
+        token0.transfer(address(migrator), 1000 ether);
+        token1.transfer(address(migrator), 1000 ether);
+        uint256 liquidity = migrator.migrate(uint160(2 ** 96), address(token0), address(token1), address(0xbeef));
+
+        assertEq(token0.balanceOf(address(migrator)), 0, "Wrong migrator token0 balance");
+        assertEq(token1.balanceOf(address(migrator)), 0, "Wrong migrator token1 balance");
+
+        assertEq(token0.balanceOf(pool), 1000 ether, "Wrong pool token0 balance");
+        assertEq(token1.balanceOf(pool), 1000 ether, "Wrong pool token1 balance");
+
+        uint256 lockedLiquidity = liquidity / 20;
+        uint256 allocatedLiquidity = liquidity * 0.1 ether / 1 ether;
+        assertEq(
+            liquidity - lockedLiquidity - allocatedLiquidity,
+            IUniswapV2Pair(pool).balanceOf(address(0xbeef)),
+            "Wrong liquidity"
+        );
+        assertEq(allocatedLiquidity, IUniswapV2Pair(pool).balanceOf(alice), "Wrong allocated liquidity");
+        assertEq(lockedLiquidity, IUniswapV2Pair(pool).balanceOf(address(migrator.locker())), "Wrong locked liquidity");
+    }
+
+    function test_migrate_AllocateLPToAlice_RevertsWhenMaxLPAllocationExceeded() public {
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
+        address alice = makeAddr("alice");
+
+        // try to allocate 20% LP to alice during migration
+        bytes memory liquidityMigratorData = abi.encode(0.2 ether, alice);
+        vm.expectRevert(abi.encodeWithSelector(UniswapV2Migrator.MaxLPAllocationExceeded.selector));
+        migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+    }
+
+    function test_migrate_AllocateLPToContract_RevertsWhenLPRecipientIsNotEOA() public {
+        // TestERC20 token0 = new TestERC20(1000 ether);
+        // TestERC20 token1 = new TestERC20(1000 ether);
+
+        // address testContract = makeAddr("testContract");
+        // vm.etch(testContract, new bytes(1));
+        // bytes memory liquidityMigratorData = abi.encode(0.1 ether, testContract);
+        // vm.expectRevert(abi.encodeWithSelector(UniswapV2Migrator.LPRecipientNotEOA.selector));
+        // migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+    }
+
     /*
     function test_migrate_MockedCalls() public {
         address token0 = makeAddr("token0");

--- a/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
@@ -65,12 +65,6 @@ contract UniswapV2LockerTest is Test {
         locker.receiveAndLock(address(pool), aliceRecipient, 30 days);
     }
 
-    function test_receiveAndLock_RevertsWhenLessThanMinLockPeriod() public {
-        vm.startPrank(address(migrator));
-        vm.expectRevert(CustomLPUniswapV2Locker.LessThanMinLockPeriod.selector);
-        locker.receiveAndLock(address(pool), aliceRecipient, 29 days);
-    }
-
     function owner() external pure { }
 
     function getAsset(

--- a/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
@@ -49,20 +49,20 @@ contract UniswapV2LockerTest is Test {
         tokenBar.transfer(address(pool), 100e18);
         pool.mint(address(locker));
         vm.prank(address(migrator));
-        locker.receiveAndLock(address(pool), aliceRecipient, 90 days);
+        locker.receiveAndLock(address(pool), aliceRecipient, 30 days);
     }
 
     function test_receiveAndLock_RevertsWhenPoolAlreadyInitialized() public {
         test_receiveAndLock_WithLockUpPeriod_InitializesPool();
         vm.startPrank(address(migrator));
         vm.expectRevert(IUniswapV2Locker.PoolAlreadyInitialized.selector);
-        locker.receiveAndLock(address(pool), aliceRecipient, 90 days);
+        locker.receiveAndLock(address(pool), aliceRecipient, 30 days);
     }
 
     function test_receiveAndLock_RevertsWhenNoBalanceToLock() public {
         vm.startPrank(address(migrator));
         vm.expectRevert(IUniswapV2Locker.NoBalanceToLock.selector);
-        locker.receiveAndLock(address(pool), aliceRecipient, 90 days);
+        locker.receiveAndLock(address(pool), aliceRecipient, 30 days);
     }
 
     function owner() external pure { }
@@ -73,7 +73,7 @@ contract UniswapV2LockerTest is Test {
 
     function test_claimFeesAndExit_RevertsWhenMinUnlockDateNotReached() public {
         test_receiveAndLock_WithLockUpPeriod_InitializesPool();
-        vm.warp(block.timestamp + 89 days);
+        vm.warp(block.timestamp + 29 days);
         vm.expectRevert(IUniswapV2Locker.MinUnlockDateNotReached.selector);
         locker.claimFeesAndExit(address(pool));
     }
@@ -98,7 +98,7 @@ contract UniswapV2LockerTest is Test {
             abi.encode(address(tokenBar))
         );
 
-        vm.warp(block.timestamp + 90 days);
+        vm.warp(block.timestamp + 30 days);
 
         locker.claimFeesAndExit(address(pool));
         assertGt(tokenBar.balanceOf(aliceRecipient), 0, "alice balance0 is wrong");

--- a/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
@@ -65,6 +65,12 @@ contract UniswapV2LockerTest is Test {
         locker.receiveAndLock(address(pool), aliceRecipient, 30 days);
     }
 
+    function test_receiveAndLock_RevertsWhenLessThanMinLockPeriod() public {
+        vm.startPrank(address(migrator));
+        vm.expectRevert(CustomLPUniswapV2Locker.LessThanMinLockPeriod.selector);
+        locker.receiveAndLock(address(pool), aliceRecipient, 29 days);
+    }
+
     function owner() external pure { }
 
     function getAsset(

--- a/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Locker.t.sol
@@ -3,18 +3,18 @@ pragma solidity ^0.8.13;
 
 import { Test } from "forge-std/Test.sol";
 import { TestERC20 } from "@v4-core/test/TestERC20.sol";
-import { UniswapV2Locker } from "src/UniswapV2Locker.sol";
 import { UNISWAP_V2_FACTORY_MAINNET, UNISWAP_V2_ROUTER_MAINNET } from "test/shared/Addresses.sol";
-import { UniswapV2Migrator } from "src/UniswapV2Migrator.sol";
 import { Airlock } from "src/Airlock.sol";
+import { CustomLPUniswapV2Migrator } from "src/extensions/CustomLPUniswapV2Migrator.sol";
+import { CustomLPUniswapV2Locker } from "src/extensions/CustomLPUniswapV2Locker.sol";
 import { IUniswapV2Locker } from "src/interfaces/IUniswapV2Locker.sol";
 import { IUniswapV2Factory } from "src/interfaces/IUniswapV2Factory.sol";
 import { IUniswapV2Pair } from "src/interfaces/IUniswapV2Pair.sol";
 import { IUniswapV2Router02 } from "src/interfaces/IUniswapV2Router02.sol";
 
 contract UniswapV2LockerTest is Test {
-    UniswapV2Locker public locker;
-    UniswapV2Migrator public migrator = UniswapV2Migrator(payable(address(0x88888)));
+    CustomLPUniswapV2Locker public locker;
+    CustomLPUniswapV2Migrator public migrator = CustomLPUniswapV2Migrator(payable(address(0x88888)));
     IUniswapV2Pair public pool;
 
     Airlock public airlock = Airlock(payable(address(0xdeadbeef)));
@@ -22,13 +22,15 @@ contract UniswapV2LockerTest is Test {
     TestERC20 public tokenFoo;
     TestERC20 public tokenBar;
 
+    address aliceRecipient = makeAddr("alice");
+
     function setUp() public {
         vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 21_093_509);
 
         tokenFoo = new TestERC20(1e25);
         tokenBar = new TestERC20(1e25);
 
-        locker = new UniswapV2Locker(
+        locker = new CustomLPUniswapV2Locker(
             address(airlock), IUniswapV2Factory(UNISWAP_V2_FACTORY_MAINNET), migrator, address(0xb055)
         );
 
@@ -42,30 +44,26 @@ contract UniswapV2LockerTest is Test {
         assertEq(address(locker.migrator()), address(migrator));
     }
 
-    function test_receiveAndLock_InitializesPool() public {
+    function test_receiveAndLock_WithLockUpPeriod_InitializesPool() public {
         tokenFoo.transfer(address(pool), 100e18);
         tokenBar.transfer(address(pool), 100e18);
         pool.mint(address(locker));
         vm.prank(address(migrator));
-        locker.receiveAndLock(address(pool), address(0xbeef));
+        locker.receiveAndLock(address(pool), aliceRecipient, 90 days);
     }
 
     function test_receiveAndLock_RevertsWhenPoolAlreadyInitialized() public {
-        test_receiveAndLock_InitializesPool();
+        test_receiveAndLock_WithLockUpPeriod_InitializesPool();
         vm.startPrank(address(migrator));
         vm.expectRevert(IUniswapV2Locker.PoolAlreadyInitialized.selector);
-        locker.receiveAndLock(address(pool), address(0xbeef));
+        locker.receiveAndLock(address(pool), aliceRecipient, 90 days);
     }
 
     function test_receiveAndLock_RevertsWhenNoBalanceToLock() public {
         vm.startPrank(address(migrator));
         vm.expectRevert(IUniswapV2Locker.NoBalanceToLock.selector);
-        locker.receiveAndLock(address(pool), address(0xbeef));
+        locker.receiveAndLock(address(pool), aliceRecipient, 90 days);
     }
-
-    function getAssetData(
-        address
-    ) external pure { }
 
     function owner() external pure { }
 
@@ -74,13 +72,14 @@ contract UniswapV2LockerTest is Test {
     ) external pure { }
 
     function test_claimFeesAndExit_RevertsWhenMinUnlockDateNotReached() public {
-        test_receiveAndLock_InitializesPool();
+        test_receiveAndLock_WithLockUpPeriod_InitializesPool();
+        vm.warp(block.timestamp + 89 days);
         vm.expectRevert(IUniswapV2Locker.MinUnlockDateNotReached.selector);
         locker.claimFeesAndExit(address(pool));
     }
 
     function test_claimFeesAndExit() public {
-        test_receiveAndLock_InitializesPool();
+        test_receiveAndLock_WithLockUpPeriod_InitializesPool();
 
         address[] memory path = new address[](2);
         path[0] = address(tokenFoo);
@@ -98,30 +97,12 @@ contract UniswapV2LockerTest is Test {
             abi.encodeWithSelector(this.getAsset.selector, address(pool)),
             abi.encode(address(tokenBar))
         );
-        address timelock = address(0xbeef);
-        vm.mockCall(
-            address(airlock),
-            abi.encodeWithSelector(this.getAssetData.selector, address(tokenBar)),
-            abi.encode(
-                address(0),
-                timelock,
-                address(0),
-                address(0),
-                address(0),
-                address(0),
-                address(0),
-                uint256(0),
-                uint256(0),
-                uint256(0),
-                address(0)
-            )
-        );
 
-        vm.warp(block.timestamp + 365 days);
+        vm.warp(block.timestamp + 90 days);
 
         locker.claimFeesAndExit(address(pool));
-        assertGt(tokenBar.balanceOf(timelock), 0, "Timelock balance0 is wrong");
-        assertGt(tokenFoo.balanceOf(timelock), 0, "Timelock balance1 is wrong");
+        assertGt(tokenBar.balanceOf(aliceRecipient), 0, "alice balance0 is wrong");
+        assertGt(tokenFoo.balanceOf(aliceRecipient), 0, "alice balance1 is wrong");
         assertGt(tokenBar.balanceOf(address(0xb055)), 0, "Owner balance0 is wrong");
         assertGt(tokenFoo.balanceOf(address(0xb055)), 0, "Owner balance1 is wrong");
         assertEq(pool.balanceOf(address(locker)), 0, "Locker balance is wrong");

--- a/test/unit/extensions/CustomLPUniswapV2Migrator.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Migrator.t.sol
@@ -27,9 +27,9 @@ contract CustomLPUniswapV2MigratorTest is Test {
     function test_migrate_CustomLPToEOA_WhenLiquidityMigratorDataNotEmpty() public {
         TestERC20 token0 = new TestERC20(1000 ether);
         TestERC20 token1 = new TestERC20(1000 ether);
-        // allocate 1% LP to alice during migration
-        uint256 customLPWad = 0.01 ether;
-        uint32 lockUpPeriod = 90 days;
+        // allocate 3% LP to alice during migration
+        uint256 customLPWad = 0.03 ether;
+        uint32 lockUpPeriod = 30 days;
         address alice = makeAddr("alice");
 
         bytes memory liquidityMigratorData = abi.encode(customLPWad, alice, lockUpPeriod);
@@ -70,7 +70,7 @@ contract CustomLPUniswapV2MigratorTest is Test {
         TestERC20 token1 = new TestERC20(1000 ether);
         // try to allocate 20% LP to alice during migration
         uint256 customLPWad = 0.2 ether;
-        uint32 lockUpPeriod = 90 days;
+        uint32 lockUpPeriod = 30 days;
         address alice = makeAddr("alice");
 
         bytes memory liquidityMigratorData = abi.encode(customLPWad, alice, lockUpPeriod);

--- a/test/unit/extensions/CustomLPUniswapV2Migrator.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Migrator.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { Test } from "forge-std/Test.sol";
+import { TestERC20 } from "@v4-core/test/TestERC20.sol";
+import { TickMath } from "@v4-core/libraries/TickMath.sol";
+import { ERC20 } from "@openzeppelin/token/ERC20/ERC20.sol";
+import { IUniswapV2Factory, IUniswapV2Router02, IUniswapV2Pair } from "src/UniswapV2Migrator.sol";
+import { CustomLPUniswapV2Migrator } from "src/extensions/CustomLPUniswapV2Migrator.sol";
+import { SenderNotAirlock } from "src/base/ImmutableAirlock.sol";
+import { MigrationMath } from "src/UniswapV2Migrator.sol";
+import { UNISWAP_V2_FACTORY_MAINNET, UNISWAP_V2_ROUTER_MAINNET, WETH_MAINNET } from "test/shared/Addresses.sol";
+
+contract CustomLPUniswapV2MigratorTest is Test {
+    CustomLPUniswapV2Migrator public migrator;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), 21_093_509);
+        migrator = new CustomLPUniswapV2Migrator(
+            address(this),
+            IUniswapV2Factory(UNISWAP_V2_FACTORY_MAINNET),
+            IUniswapV2Router02(UNISWAP_V2_ROUTER_MAINNET),
+            address(0xb055)
+        );
+    }
+
+    function test_migrate_CustomLPToEOA_WhenLiquidityMigratorDataNotEmpty() public {
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
+        // allocate 1% LP to alice during migration
+        uint256 customLPWad = 0.01 ether;
+        uint32 lockUpPeriod = 90 days;
+        address alice = makeAddr("alice");
+
+        bytes memory liquidityMigratorData = abi.encode(customLPWad, alice, lockUpPeriod);
+        address pool = migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+
+        assertEq(migrator.customLPWad(), customLPWad, "Wrong custom LP wad");
+        assertEq(migrator.lockUpPeriod(), lockUpPeriod, "Wrong lock up period");
+        assertEq(migrator.customLPRecipient(), alice, "Wrong custom LP recipient");
+
+        token0.transfer(address(migrator), 1000 ether);
+        token1.transfer(address(migrator), 1000 ether);
+        uint256 liquidity = migrator.migrate(uint160(2 ** 96), address(token0), address(token1), address(0xbeef));
+
+        assertEq(token0.balanceOf(address(migrator)), 0, "Wrong migrator token0 balance");
+        assertEq(token1.balanceOf(address(migrator)), 0, "Wrong migrator token1 balance");
+
+        assertEq(token0.balanceOf(pool), 1000 ether, "Wrong pool token0 balance");
+        assertEq(token1.balanceOf(pool), 1000 ether, "Wrong pool token1 balance");
+
+        uint256 lockedLiquidity = liquidity / 20;
+        uint256 customLockedLiquidity = liquidity * customLPWad / 1 ether;
+        assertEq(
+            liquidity - lockedLiquidity - customLockedLiquidity,
+            IUniswapV2Pair(pool).balanceOf(address(0xbeef)),
+            "Wrong liquidity"
+        );
+        assertEq(0, IUniswapV2Pair(pool).balanceOf(alice), "Wrong custom locked liquidity");
+        assertEq(lockedLiquidity, IUniswapV2Pair(pool).balanceOf(address(migrator.locker())), "Wrong locked liquidity");
+        assertEq(
+            customLockedLiquidity,
+            IUniswapV2Pair(pool).balanceOf(address(migrator.customLPLocker())),
+            "Wrong custom locked liquidity"
+        );
+    }
+
+    function test_migrate_CustomLPToEOA_RevertsWhenMaxLPAllocationExceeded() public {
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
+        // try to allocate 20% LP to alice during migration
+        uint256 customLPWad = 0.2 ether;
+        uint32 lockUpPeriod = 90 days;
+        address alice = makeAddr("alice");
+
+        bytes memory liquidityMigratorData = abi.encode(customLPWad, alice, lockUpPeriod);
+        vm.expectRevert(abi.encodeWithSelector(CustomLPUniswapV2Migrator.MaxCustomLPWadExceeded.selector));
+        migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+    }
+
+    function test_migrate_CustomLPToSmartContract_RevertsWhenLPRecipientIsNotEOA() public {
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
+        uint256 customLPWad = 0.01 ether;
+        uint32 lockUpPeriod = 30 days;
+        address testContract = makeAddr("testContract");
+        vm.etch(testContract, new bytes(1));
+
+        bytes memory liquidityMigratorData = abi.encode(customLPWad, testContract, lockUpPeriod);
+        vm.expectRevert(abi.encodeWithSelector(CustomLPUniswapV2Migrator.RecipientNotEOA.selector));
+        migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+    }
+}

--- a/test/unit/extensions/CustomLPUniswapV2Migrator.t.sol
+++ b/test/unit/extensions/CustomLPUniswapV2Migrator.t.sol
@@ -90,4 +90,16 @@ contract CustomLPUniswapV2MigratorTest is Test {
         vm.expectRevert(abi.encodeWithSelector(CustomLPUniswapV2Migrator.RecipientNotEOA.selector));
         migrator.initialize(address(token0), address(token1), liquidityMigratorData);
     }
+
+    function test_migrate_CustomLPToSmartContract_RevertsWhenLessThanMinLockPeriod() public {
+        TestERC20 token0 = new TestERC20(1000 ether);
+        TestERC20 token1 = new TestERC20(1000 ether);
+        uint256 customLPWad = 0.03 ether;
+        uint32 lockUpPeriod = 29 days;
+        address alice = makeAddr("alice");
+
+        bytes memory liquidityMigratorData = abi.encode(customLPWad, alice, lockUpPeriod);
+        vm.expectRevert(abi.encodeWithSelector(CustomLPUniswapV2Migrator.LessThanMinLockPeriod.selector));
+        migrator.initialize(address(token0), address(token1), liquidityMigratorData);
+    }
 }


### PR DESCRIPTION
Closes #356 

A feature for v2 migrator to allow creators to allocate LP tokens to a recipient without vesting during `migrate`, I try to keep the implementation minimal without affecting the current logic much

- this custom allocation will only be effective when creator pass non-empty `liquidityMigratorData`
- currently allow at max **5%** of LPs to be allocated to the recipient with at least 1-month vesting
- to avoid overcomplicated changes to Migrator e.g. checking if the contract has callback function to transfer out the LP token; a simple checking on `code.length` is added to make sure the recipient has to be an EOA
- other misc changes include removing unused comments, use constant instead of hardcoded inline numbers