### PR TITLE
V4 simulation tests

### DIFF
--- a/test/shared/BaseTest.sol
+++ b/test/shared/BaseTest.sol
@@ -57,7 +57,7 @@ contract BaseTest is Test, Deployers {
     uint256 constant DEFAULT_STARTING_TIME = 1 days;
     uint256 constant DEFAULT_ENDING_TIME = DEFAULT_STARTING_TIME + SALE_DURATION;
 
-    int24 constant DEFAULT_GAMMA = 6400;
+    int24 constant DEFAULT_GAMMA = 800;
     uint256 constant DEFAULT_EPOCH_LENGTH = 400 seconds;
 
     // default to feeless case for now

--- a/test/shared/BaseTest.sol
+++ b/test/shared/BaseTest.sol
@@ -60,9 +60,8 @@ contract BaseTest is Test, Deployers {
     // uint256 constant DEFAULT_ENDING_TIME = 2 days;
     uint256 constant DEFAULT_ENDING_TIME = DEFAULT_STARTING_TIME + 10 hours;
 
-    // int24 constant DEFAULT_GAMMA = 43_736;
-    // int24 constant DEFAULT_GAMMA = 59_780;
-    int24 constant DEFAULT_GAMMA = 18_850;
+    // int24 constant DEFAULT_GAMMA = 18850;
+    int24 constant DEFAULT_GAMMA = 26_630;
     // int24 constant DEFAULT_GAMMA = 800;
     uint256 constant DEFAULT_EPOCH_LENGTH = 400 seconds;
 
@@ -70,14 +69,14 @@ contract BaseTest is Test, Deployers {
     uint24 constant DEFAULT_FEE = 0;
     // int24 constant DEFAULT_TICK_SPACING = 8;
     int24 constant DEFAULT_TICK_SPACING = 10;
-    uint256 constant DEFAULT_NUM_PD_SLUGS = 10;
+    uint256 constant DEFAULT_NUM_PD_SLUGS = 3;
 
     // int24 constant DEFAULT_START_TICK = 1600;
     // int24 constant DEFAULT_END_TICK = 171_200;
     // int24 constant DEFAULT_START_TICK = -184_210;
     // int24 constant DEFAULT_END_TICK = 353_810;
     int24 constant DEFAULT_START_TICK = -161_180;
-    int24 constant DEFAULT_END_TICK = 330_780;
+    int24 constant DEFAULT_END_TICK = 400_780;
 
     address constant TOKEN_A = address(0x8888);
     address constant TOKEN_B = address(0x9999);

--- a/test/shared/BaseTest.sol
+++ b/test/shared/BaseTest.sol
@@ -50,21 +50,34 @@ contract BaseTest is Test, Deployers {
 
     // Constants
 
-    uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 100_000e18;
-    uint256 constant DEFAULT_MINIMUM_PROCEEDS = 100e18;
-    uint256 constant DEFAULT_MAXIMUM_PROCEEDS = 10_000e18;
+    // uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 100_000e18;
+    // uint256 constant DEFAULT_MINIMUM_PROCEEDS = 100e18;
+    // uint256 constant DEFAULT_MAXIMUM_PROCEEDS = 10_000e18;
+    uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 900_000_000e18; // 900M tokens
+    uint256 constant DEFAULT_MINIMUM_PROCEEDS = 6667e15; // 6.667 eth
+    uint256 constant DEFAULT_MAXIMUM_PROCEEDS = 13_333e15; // 13.333 eth
     uint256 constant DEFAULT_STARTING_TIME = 1 days;
-    uint256 constant DEFAULT_ENDING_TIME = 2 days;
-    int24 constant DEFAULT_GAMMA = 800;
+    // uint256 constant DEFAULT_ENDING_TIME = 2 days;
+    uint256 constant DEFAULT_ENDING_TIME = DEFAULT_STARTING_TIME + 10 hours;
+
+    // int24 constant DEFAULT_GAMMA = 43_736;
+    // int24 constant DEFAULT_GAMMA = 59_780;
+    int24 constant DEFAULT_GAMMA = 18_850;
+    // int24 constant DEFAULT_GAMMA = 800;
     uint256 constant DEFAULT_EPOCH_LENGTH = 400 seconds;
 
     // default to feeless case for now
     uint24 constant DEFAULT_FEE = 0;
-    int24 constant DEFAULT_TICK_SPACING = 8;
-    uint256 constant DEFAULT_NUM_PD_SLUGS = 3;
+    // int24 constant DEFAULT_TICK_SPACING = 8;
+    int24 constant DEFAULT_TICK_SPACING = 10;
+    uint256 constant DEFAULT_NUM_PD_SLUGS = 10;
 
-    int24 constant DEFAULT_START_TICK = 1600;
-    int24 constant DEFAULT_END_TICK = 171_200;
+    // int24 constant DEFAULT_START_TICK = 1600;
+    // int24 constant DEFAULT_END_TICK = 171_200;
+    // int24 constant DEFAULT_START_TICK = -184_210;
+    // int24 constant DEFAULT_END_TICK = 353_810;
+    int24 constant DEFAULT_START_TICK = -161_180;
+    int24 constant DEFAULT_END_TICK = 330_780;
 
     address constant TOKEN_A = address(0x8888);
     address constant TOKEN_B = address(0x9999);

--- a/test/shared/BaseTest.sol
+++ b/test/shared/BaseTest.sol
@@ -49,34 +49,24 @@ contract BaseTest is Test, Deployers {
     }
 
     // Constants
+    uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 100_000e18;
+    uint256 constant DEFAULT_MINIMUM_PROCEEDS = 100e18;
+    uint256 constant DEFAULT_MAXIMUM_PROCEEDS = 10_000e18;
 
-    // uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 100_000e18;
-    // uint256 constant DEFAULT_MINIMUM_PROCEEDS = 100e18;
-    // uint256 constant DEFAULT_MAXIMUM_PROCEEDS = 10_000e18;
-    uint256 constant DEFAULT_NUM_TOKENS_TO_SELL = 900_000_000e18; // 900M tokens
-    uint256 constant DEFAULT_MINIMUM_PROCEEDS = 6667e15; // 6.667 eth
-    uint256 constant DEFAULT_MAXIMUM_PROCEEDS = 13_333e15; // 13.333 eth
+    uint256 constant SALE_DURATION = 1 days;
     uint256 constant DEFAULT_STARTING_TIME = 1 days;
-    // uint256 constant DEFAULT_ENDING_TIME = 2 days;
-    uint256 constant DEFAULT_ENDING_TIME = DEFAULT_STARTING_TIME + 10 hours;
+    uint256 constant DEFAULT_ENDING_TIME = DEFAULT_STARTING_TIME + SALE_DURATION;
 
-    // int24 constant DEFAULT_GAMMA = 18850;
-    int24 constant DEFAULT_GAMMA = 26_630;
-    // int24 constant DEFAULT_GAMMA = 800;
+    int24 constant DEFAULT_GAMMA = 6400;
     uint256 constant DEFAULT_EPOCH_LENGTH = 400 seconds;
 
     // default to feeless case for now
     uint24 constant DEFAULT_FEE = 0;
-    // int24 constant DEFAULT_TICK_SPACING = 8;
-    int24 constant DEFAULT_TICK_SPACING = 10;
+    int24 constant DEFAULT_TICK_SPACING = 8;
     uint256 constant DEFAULT_NUM_PD_SLUGS = 3;
 
-    // int24 constant DEFAULT_START_TICK = 1600;
-    // int24 constant DEFAULT_END_TICK = 171_200;
-    // int24 constant DEFAULT_START_TICK = -184_210;
-    // int24 constant DEFAULT_END_TICK = 353_810;
-    int24 constant DEFAULT_START_TICK = -161_180;
-    int24 constant DEFAULT_END_TICK = 400_780;
+    int24 constant DEFAULT_START_TICK = 1600;
+    int24 constant DEFAULT_END_TICK = 171_200;
 
     address constant TOKEN_A = address(0x8888);
     address constant TOKEN_B = address(0x9999);

--- a/test/shared/V4PocTest.sol
+++ b/test/shared/V4PocTest.sol
@@ -304,82 +304,82 @@ contract V4PocTest is DopplerLensTest {
         console.log("ETH migrated: ", address(0xbeef).balance);
     }
 
-    function test_buy_60sPerEpoch_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
+    // function test_buy_60sPerEpoch_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
+    //     // Go to starting time
+    //     vm.warp(hook.getStartingTime());
 
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+    //     (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
 
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
+    //     console.log("\n-------------- CURRENT CONFIG ------------------");
+    //     console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+    //     console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+    //     console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+    //     console.log("starting tick", hook.getStartingTick());
+    //     console.log("ending tick", hook.getEndingTick());
+    //     console.log("gamma", hook.getGamma());
 
-        // no buys for N epochs
-        uint256 totalEpochs = 360;
-        uint256 halfOfEpoch = totalEpochs / 2;
-        uint256 maxProceed = 13_333e15;
-        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
+    //     // no buys for N epochs
+    //     uint256 totalEpochs = 360;
+    //     uint256 halfOfEpoch = totalEpochs / 2;
+    //     uint256 maxProceed = 13_333e15;
+    //     uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
 
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
+    //     vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
 
-        // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
+    //     // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
 
-        // consecutive buy in each epoch
-        for (uint256 i; i < halfOfEpoch; i++) {
-            uint256 tokenBought;
+    //     // consecutive buy in each epoch
+    //     for (uint256 i; i < halfOfEpoch; i++) {
+    //         uint256 tokenBought;
 
-            // if (i == halfOfEpoch - 1) {
-            (tokenBought,) = buy(-int256(buyEthAmount));
+    //         // if (i == halfOfEpoch - 1) {
+    //         (tokenBought,) = buy(-int256(buyEthAmount));
 
-            // } else {
-            //     (tokenBought,) = buy(-int256(0.0740556 ether));
-            //     sellExactIn(tokenBought / 2);
-            //     buyExactOut(tokenBought / 2);
-            // }
+    //         // } else {
+    //         //     (tokenBought,) = buy(-int256(0.0740556 ether));
+    //         //     sellExactIn(tokenBought / 2);
+    //         //     buyExactOut(tokenBought / 2);
+    //         // }
 
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+    //         (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
 
-            uint160 sqrtPriceX96;
-            int24 tick;
+    //         uint160 sqrtPriceX96;
+    //         int24 tick;
 
-            if (i == halfOfEpoch - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
+    //         if (i == halfOfEpoch - 1) {
+    //             (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+    //         } else {
+    //             (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+    //                 IV4Quoter.QuoteExactSingleParams({
+    //                     poolKey: key,
+    //                     zeroForOne: !isToken0,
+    //                     exactAmount: 1,
+    //                     hookData: ""
+    //                 })
+    //             );
+    //         }
+    //         uint256 tokenPerOneETH = sqrtPriceX96;
 
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
+    //         console.log("\n-------------- SALE No. %d ------------------", i);
+    //         console.log("tick", tick);
+    //         console.log("token bought", tokenBought);
+    //         console.log("\n");
+    //         console.log("totalTokensSold / circulating supply", totalTokensSold);
+    //         console.log("totalProceeds", totalProceeds);
+    //         console.log("\n");
+    //         console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+    //         console.log("isEarlyExit", hook.earlyExit());
+    //         console.log("current epoch", hook.getCurrentEpoch());
 
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
-        }
+    //         vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
+    //     }
 
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
+    //     vm.prank(hook.initializer());
+    //     hook.migrate(address(0xbeef));
 
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
+    //     console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+    //     console.log("ETH migrated: ", address(0xbeef).balance);
+    // }
 
     function test_buy_24hrSale_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
         // Go to starting time
@@ -659,6 +659,74 @@ contract V4PocTest is DopplerLensTest {
             console.log("current epoch", hook.getCurrentEpoch());
 
             vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_EveryEpochUntilMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        uint256 tradeNum = 14;
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < tradeNum; i++) {
+            uint256 tokenBought;
+
+            if (i == tradeNum - 1) {
+                (tokenBought,) = buy(-int256(1 ether));
+            } else {
+                (tokenBought,) = buy(-int256(1 ether));
+                sellExactIn(tokenBought / 2);
+                buyExactOut(tokenBought / 2);
+            }
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == tradeNum - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (tradeNum + i + 1)); // go to next epoch
         }
 
         vm.prank(hook.initializer());

--- a/test/shared/V4PocTest.sol
+++ b/test/shared/V4PocTest.sol
@@ -69,7 +69,7 @@ contract V4PocTest is DopplerLensTest {
         console.log("tick(tokenPerOneETH)", tick);
     }
 
-    function test_buy_EmptyEpochsForHalfSale_BuyWithinFixedEpochsUntilMaxProceed() public {
+    function test_buy_EmptyFixedEpochs_BuyWithinFixedEpochsUntilMaxProceed() public {
         // Go to starting time
         vm.warp(hook.startingTime());
 
@@ -82,12 +82,22 @@ contract V4PocTest is DopplerLensTest {
         console.log("starting tick", hook.startingTick());
         console.log("ending tick", hook.endingTick());
         console.log("gamma", hook.gamma());
+        console.log("\n");
+        console.log("numeraire ", numeraire);
+        console.log("asset ", asset);
+        console.log("isToken0 ", isToken0);
+        console.log("usingEth ", usingEth);
+        console.log("current epoch", hook.getCurrentEpoch());
 
         // no buys for N epochs
+        uint256 emptyEpochs = 5;
+        // buy with same size for N epochs
         uint256 fixedEpochs = 10;
-        uint256 buyEthAmount = DEFAULT_MAXIMUM_PROCEEDS / fixedEpochs + 1; // in case max proceed is not divisible by the number of epochs
 
-        vm.warp(hook.startingTime() + hook.epochLength() * fixedEpochs);
+        // time travel by `emptyEpochs`
+        vm.warp(hook.startingTime() + hook.epochLength() * emptyEpochs);
+
+        uint256 buyEthAmount = DEFAULT_MAXIMUM_PROCEEDS / fixedEpochs + 1; // in case max proceed is not divisible by the number of epochs
 
         // consecutive buy with same size in each epoch
         for (uint256 i; i < fixedEpochs; i++) {
@@ -113,7 +123,7 @@ contract V4PocTest is DopplerLensTest {
                 );
             }
 
-            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("\n-------------- SALE No. %d ------------------", i + 1);
             console.log("current epoch", hook.getCurrentEpoch());
             console.log("token bought", tokenBought);
             console.log("totalTokensSold / circulating supply", totalTokensSold);
@@ -123,7 +133,7 @@ contract V4PocTest is DopplerLensTest {
             console.log("tick(tokenPerOneETH)", tick);
             console.log("isEarlyExit", hook.earlyExit());
 
-            vm.warp(hook.startingTime() + hook.epochLength() * (fixedEpochs + i + 1)); // go to next epoch
+            vm.warp(hook.startingTime() + hook.epochLength() * (emptyEpochs + i + 1)); // go to next epoch
         }
 
         vm.prank(hook.initializer());
@@ -146,11 +156,20 @@ contract V4PocTest is DopplerLensTest {
         console.log("starting tick", hook.startingTick());
         console.log("ending tick", hook.endingTick());
         console.log("gamma", hook.gamma());
+        console.log("\n");
+        console.log("numeraire ", numeraire);
+        console.log("asset ", asset);
+        console.log("isToken0 ", isToken0);
+        console.log("usingEth ", usingEth);
+        console.log("current epoch", hook.getCurrentEpoch());
 
+        uint256 totalEpochs = SALE_DURATION / DEFAULT_EPOCH_LENGTH;
         uint256 fixedEpochs = 10;
+        assert(totalEpochs > fixedEpochs);
+
         uint256 buyEthAmount = DEFAULT_MAXIMUM_PROCEEDS / fixedEpochs + 1; // in case max proceed is not divisible by the number of epochs
 
-        // consecutive buy in each epoch
+        // consecutive buy with same size in each epoch
         for (uint256 i; i < fixedEpochs; i++) {
             (uint256 tokenBought,) = buy(-int256(buyEthAmount));
 
@@ -172,7 +191,7 @@ contract V4PocTest is DopplerLensTest {
                 );
             }
 
-            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("\n-------------- SALE No. %d ------------------", i + 1);
             console.log("current epoch", hook.getCurrentEpoch());
             console.log("token bought", tokenBought);
             console.log("totalTokensSold / circulating supply", totalTokensSold);
@@ -182,7 +201,7 @@ contract V4PocTest is DopplerLensTest {
             console.log("tick(tokenPerOneETH)", tick);
             console.log("isEarlyExit", hook.earlyExit());
 
-            vm.warp(hook.startingTime() + hook.epochLength() * (fixedEpochs + i + 1)); // go to next epoch
+            vm.warp(hook.startingTime() + hook.epochLength() * (i + 1)); // go to next epoch
         }
 
         vm.prank(hook.initializer());
@@ -207,6 +226,11 @@ contract V4PocTest is DopplerLensTest {
         console.log("starting tick", hook.startingTick());
         console.log("ending tick", hook.endingTick());
         console.log("gamma", hook.gamma());
+        console.log("\n");
+        console.log("numeraire ", numeraire);
+        console.log("asset ", asset);
+        console.log("isToken0 ", isToken0);
+        console.log("usingEth ", usingEth);
         console.log("current epoch", hook.getCurrentEpoch());
 
         (uint256 tokenBought,) = buy(-maximumProceeds);

--- a/test/shared/V4PocTest.sol
+++ b/test/shared/V4PocTest.sol
@@ -5,8 +5,9 @@ import { Test, console } from "forge-std/Test.sol";
 import { StateLibrary } from "@v4-core/libraries/StateLibrary.sol";
 import { TickMath } from "@v4-core/libraries/TickMath.sol";
 import { PoolManager, IPoolManager } from "@v4-core/PoolManager.sol";
-import { IV4Quoter } from "@uniswap/v4-periphery/src/interfaces/IV4Quoter.sol";
+import { IV4Quoter } from "@v4-periphery/lens/V4Quoter.sol";
 import { DopplerLensTest } from "test/unit/DopplerLens.t.sol";
+import { BaseTest } from "test/shared/BaseTest.sol";
 import { State } from "src/Doppler.sol";
 
 interface IERC20 {
@@ -18,721 +19,217 @@ interface IERC20 {
 using StateLibrary for IPoolManager;
 
 contract V4PocTest is DopplerLensTest {
-    function test_v4_emptyEpochForHalfSale_ThenBuy1ETH() public _deployLensQuoter {
+    function test_buy_EmptyEpochsForHalfSale_Buy1ETHAtNextEpoch() public {
         // Go to starting time
-        vm.warp(hook.getStartingTime());
+        vm.warp(hook.startingTime());
 
         (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-        uint256 oriTokenBalance = IERC20(asset).balanceOf(address(this));
 
         console.log("\n-------------- CURRENT CONFIG ------------------");
         console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
         console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
         console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
+        console.log("starting tick", hook.startingTick());
+        console.log("ending tick", hook.endingTick());
+        console.log("gamma", hook.gamma());
         console.log("\n");
         console.log("numeraire ", numeraire);
         console.log("asset ", asset);
         console.log("isToken0 ", isToken0);
         console.log("usingEth ", usingEth);
+        console.log("current epoch", hook.getCurrentEpoch());
 
         // no buys for N epochs
-        uint256 skipNumOfEpoch = 45; // 5 hrs
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
+        uint256 totalEpochs = SALE_DURATION / DEFAULT_EPOCH_LENGTH;
+        // time travel to half of the sale
+        vm.warp(hook.startingTime() + hook.epochLength() * (totalEpochs / 2 - 1));
 
-        // buyExactOut(1);
-
-        // // quote the price
-        // (uint160 quotedSqrtPriceX96, int24 quotedTick) = lensQuoter.quoteDopplerLensData(
-        //     IV4Quoter.QuoteExactSingleParams({ poolKey: key, zeroForOne: !isToken0, exactAmount: 1, hookData: "" })
-        // );
-        // console.log("epoch 46 quoted sqrtPriceX96", quotedSqrtPriceX96);
-        // console.log("epoch 46 tick", quotedTick);
-
-        uint256 tokenBalB4 = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
-
-        // get expected amount sold for the current epoch
-        // uint256 expectedAmountSold = hook.getExpectedAmountSoldWithEpochOffset(1);
-
-        // NOTE: CHANGE BUY AMOUNT HERE
+        // buy 1 ETH at next epoch
+        vm.warp(hook.startingTime() + hook.epochLength() * (totalEpochs / 2));
         (uint256 tokenBought,) = buy(-int256(1 ether));
-        // (uint256 tokenBought,) = buy(int256(expectedAmountSold));
 
         uint256 tokenLeft = IERC20(asset).balanceOf(address(manager));
         uint256 tokenLeftInHook = IERC20(asset).balanceOf(address(hook));
-        uint256 tokenBalAfter = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
-        // uint256 ethLeft = address(manager).balance;
         (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
 
-        // (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(key.toId());
         (uint160 sqrtPriceX96, int24 tick) = lensQuoter.quoteDopplerLensData(
             IV4Quoter.QuoteExactSingleParams({ poolKey: key, zeroForOne: !isToken0, exactAmount: 1, hookData: "" })
         );
-        uint256 tokenPerOneETH = sqrtPriceX96;
 
         console.log("\n-------------- SALE ------------------");
-        console.log("tick", tick);
-        console.log("token left in hook", tokenLeftInHook);
+        console.log("current epoch", hook.getCurrentEpoch());
         console.log("token left in pool", tokenLeft);
-        console.log("token bal b4", tokenBalB4);
-        console.log("token bal af", tokenBalAfter);
-        console.log("token bought", tokenBought);
+        console.log("token left in hook", tokenLeftInHook);
         console.log("\n");
+        console.log("token bought", tokenBought);
         console.log("totalTokensSold / circulating supply", totalTokensSold);
         console.log("totalProceeds", totalProceeds);
         console.log("\n");
-        console.log("tokenPerOneETH / sqrtPriceX96", tokenPerOneETH);
-        console.log("current epoch", hook.getCurrentEpoch());
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + 1)); // go to next epoch
+        console.log("sqrtPriceX96(ethPerOneToken)", sqrtPriceX96);
+        console.log("tick(tokenPerOneETH)", tick);
     }
 
-    function test_v4_buyMaxProceed() public _deployLensQuoter {
+    function test_buy_EmptyEpochsForHalfSale_BuyWithinFixedEpochsUntilMaxProceed() public {
         // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        int256 maximumProceeds = int256(hook.getMaximumProceeds());
+        vm.warp(hook.startingTime());
 
         (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-        uint256 oriTokenBalance = IERC20(asset).balanceOf(address(this));
 
         console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
         console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
         console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
+        console.log("starting tick", hook.startingTick());
+        console.log("ending tick", hook.endingTick());
+        console.log("gamma", hook.gamma());
 
-        // quote the price
-        (uint160 quotedSqrtPriceX96, int24 quotedTick) = lensQuoter.quoteDopplerLensData(
-            IV4Quoter.QuoteExactSingleParams({ poolKey: key, zeroForOne: !isToken0, exactAmount: 1, hookData: "" })
-        );
-        console.log("\n");
-        console.log("quoted sqrtPriceX96", quotedSqrtPriceX96);
-        console.log("quoted tick", quotedTick);
+        // no buys for N epochs
+        uint256 fixedEpochs = 10;
+        uint256 buyEthAmount = DEFAULT_MAXIMUM_PROCEEDS / fixedEpochs + 1; // in case max proceed is not divisible by the number of epochs
 
-        uint256 tokenBalB4 = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+        vm.warp(hook.startingTime() + hook.epochLength() * fixedEpochs);
+
+        // consecutive buy with same size in each epoch
+        for (uint256 i; i < fixedEpochs; i++) {
+            uint256 tokenBought;
+
+            (tokenBought,) = buy(-int256(buyEthAmount));
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == fixedEpochs - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("current epoch", hook.getCurrentEpoch());
+            console.log("token bought", tokenBought);
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("sqrtPriceX96(ethPerOneToken)", sqrtPriceX96);
+            console.log("tick(tokenPerOneETH)", tick);
+            console.log("isEarlyExit", hook.earlyExit());
+
+            vm.warp(hook.startingTime() + hook.epochLength() * (fixedEpochs + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_BuyWithinFixedEpochsUntilMaxProceed() public {
+        // Go to starting time
+        vm.warp(hook.startingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.startingTick());
+        console.log("ending tick", hook.endingTick());
+        console.log("gamma", hook.gamma());
+
+        uint256 fixedEpochs = 10;
+        uint256 buyEthAmount = DEFAULT_MAXIMUM_PROCEEDS / fixedEpochs + 1; // in case max proceed is not divisible by the number of epochs
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < fixedEpochs; i++) {
+            (uint256 tokenBought,) = buy(-int256(buyEthAmount));
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == fixedEpochs - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("current epoch", hook.getCurrentEpoch());
+            console.log("token bought", tokenBought);
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("sqrtPriceX96(ethPerOneToken)", sqrtPriceX96);
+            console.log("tick(tokenPerOneETH)", tick);
+            console.log("isEarlyExit", hook.earlyExit());
+
+            vm.warp(hook.startingTime() + hook.epochLength() * (fixedEpochs + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_v4_buyMaxProceedAtFirstEpoch() public {
+        // Go to starting time
+        vm.warp(hook.startingTime());
+
+        int256 maximumProceeds = int256(hook.maximumProceeds());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.startingTick());
+        console.log("ending tick", hook.endingTick());
+        console.log("gamma", hook.gamma());
+        console.log("current epoch", hook.getCurrentEpoch());
 
         (uint256 tokenBought,) = buy(-maximumProceeds);
 
-        uint256 tokenLeft = IERC20(asset).balanceOf(address(manager));
-        uint256 tokenLeftInHook = IERC20(asset).balanceOf(address(hook));
-        uint256 tokenBalAfter = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
-        uint256 ethLeft = address(manager).balance;
         (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
 
         (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(key.toId());
 
-        uint256 tokenPerOneETH = sqrtPriceX96;
-
         console.log("\n-------------- SALE ------------------");
-        console.log("tick", tick);
-        console.log("token left in hook", tokenLeftInHook);
-        console.log("token left in pool", tokenLeft);
-        console.log("token bal b4", tokenBalB4);
-        console.log("token bal af", tokenBalAfter);
+        console.log("current epoch", hook.getCurrentEpoch());
         console.log("token bought", tokenBought);
-        console.log("eth left", ethLeft);
-        console.log("\n");
         console.log("totalTokensSold / circulating supply", totalTokensSold);
         console.log("totalProceeds", totalProceeds);
         console.log("\n");
-        console.log("tokenPerOneETH/sqrtPriceX96", tokenPerOneETH);
+        console.log("sqrtPriceX96(ethPerOneToken)", sqrtPriceX96);
+        console.log("tick(tokenPerOneETH)", tick);
         console.log("isEarlyExit", hook.earlyExit());
 
-        vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    function testFuzz_buy_5EmptyEpoch_DiffSizeUntilMaxProceed(
-        uint256 buyEtherAmount,
-        uint256 sellEtherAmount,
-        uint256 buyBackEtherAmount
-    ) public _deployLensQuoter {
-        uint256 amount = 1.333 ether;
-        buyEtherAmount = bound(buyEtherAmount, amount, amount + 0.05 ether);
-        sellEtherAmount = bound(sellEtherAmount, 0.55 ether, amount / 2);
-        buyBackEtherAmount = bound(buyBackEtherAmount, 0.55 ether, amount / 2);
-
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-        uint256 oriTokenBalance = IERC20(asset).balanceOf(address(this));
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        // no buys for N epochs
-        uint256 skipNumOfEpoch = 5;
-        uint256 tradeNum = 10;
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
-
-        // consecutive trades in each epoch
-        for (uint256 i; i < tradeNum; i++) {
-            uint256 tokenBalB4 = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
-
-            uint256 tokenBought;
-
-            (tokenBought,) = buy(-int256(buyEtherAmount));
-            sellExactIn(sellEtherAmount);
-            buyExactOut(buyBackEtherAmount);
-
-            uint256 tokenBalAfter = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            if (i == tradeNum - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bal b4", tokenBalB4);
-            console.log("token bal af", tokenBalAfter);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    function test_buy_45emptyEpoch_45SameSizeUntilMaxProceed() public _deployLensQuoter {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        // no buys for N epochs
-        uint256 totalEpochs = 90;
-        uint256 halfOfEpoch = totalEpochs / 2;
-        uint256 maxProceed = 13_333e15;
-        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
-
-        console.log("buyEthAmount", buyEthAmount);
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
-
-        // consecutive buy in each epoch
-        for (uint256 i; i < halfOfEpoch; i++) {
-            uint256 tokenBought;
-
-            (tokenBought,) = buy(-int256(buyEthAmount));
-
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            if (i == halfOfEpoch - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    // function test_buy_60sPerEpoch_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
-    //     // Go to starting time
-    //     vm.warp(hook.getStartingTime());
-
-    //     (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-    //     console.log("\n-------------- CURRENT CONFIG ------------------");
-    //     console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-    //     console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-    //     console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-    //     console.log("starting tick", hook.getStartingTick());
-    //     console.log("ending tick", hook.getEndingTick());
-    //     console.log("gamma", hook.getGamma());
-
-    //     // no buys for N epochs
-    //     uint256 totalEpochs = 360;
-    //     uint256 halfOfEpoch = totalEpochs / 2;
-    //     uint256 maxProceed = 13_333e15;
-    //     uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
-
-    //     vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
-
-    //     // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
-
-    //     // consecutive buy in each epoch
-    //     for (uint256 i; i < halfOfEpoch; i++) {
-    //         uint256 tokenBought;
-
-    //         // if (i == halfOfEpoch - 1) {
-    //         (tokenBought,) = buy(-int256(buyEthAmount));
-
-    //         // } else {
-    //         //     (tokenBought,) = buy(-int256(0.0740556 ether));
-    //         //     sellExactIn(tokenBought / 2);
-    //         //     buyExactOut(tokenBought / 2);
-    //         // }
-
-    //         (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-    //         uint160 sqrtPriceX96;
-    //         int24 tick;
-
-    //         if (i == halfOfEpoch - 1) {
-    //             (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-    //         } else {
-    //             (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-    //                 IV4Quoter.QuoteExactSingleParams({
-    //                     poolKey: key,
-    //                     zeroForOne: !isToken0,
-    //                     exactAmount: 1,
-    //                     hookData: ""
-    //                 })
-    //             );
-    //         }
-    //         uint256 tokenPerOneETH = sqrtPriceX96;
-
-    //         console.log("\n-------------- SALE No. %d ------------------", i);
-    //         console.log("tick", tick);
-    //         console.log("token bought", tokenBought);
-    //         console.log("\n");
-    //         console.log("totalTokensSold / circulating supply", totalTokensSold);
-    //         console.log("totalProceeds", totalProceeds);
-    //         console.log("\n");
-    //         console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-    //         console.log("isEarlyExit", hook.earlyExit());
-    //         console.log("current epoch", hook.getCurrentEpoch());
-
-    //         vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
-    //     }
-
-    //     vm.prank(hook.initializer());
-    //     hook.migrate(address(0xbeef));
-
-    //     console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-    //     console.log("ETH migrated: ", address(0xbeef).balance);
-    // }
-
-    function test_buy_24hrSale_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        // no buys for N epochs
-        uint256 totalEpochs = 216;
-        uint256 halfOfEpoch = totalEpochs / 2;
-        uint256 maxProceed = 13_333e15;
-        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
-
-        // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
-
-        // consecutive buy in each epoch
-        for (uint256 i; i < halfOfEpoch; i++) {
-            uint256 tokenBought;
-
-            (tokenBought,) = buy(-int256(buyEthAmount));
-
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            if (i == halfOfEpoch - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    function test_buy_10hrSale_50ETHProceed_100sPerEpoch_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed()
-        public
-        _deployLensQuoter
-    {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        // no buys for N epochs
-        uint256 totalEpochs = 360;
-        uint256 halfOfEpoch = totalEpochs / 2;
-        uint256 maxProceed = 50 ether;
-        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
-
-        // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
-
-        // consecutive buy in each epoch
-        for (uint256 i; i < halfOfEpoch; i++) {
-            uint256 tokenBought;
-
-            (tokenBought,) = buy(-int256(buyEthAmount));
-
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            // if (i == halfOfEpoch - 1) {
-            (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            // } else {
-            //     (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-            //         IV4Quoter.QuoteExactSingleParams({
-            //             poolKey: key,
-            //             zeroForOne: !isToken0,
-            //             exactAmount: 1,
-            //             hookData: ""
-            //         })
-            //     );
-            // }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    function test_buy_60emptyEpoch_30SameSizeUntilMaxProceed() public _deployLensQuoter {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        // no buys for N epochs
-        uint256 skipNumOfEpoch = 60;
-        uint256 tradeNum = 30;
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
-
-        // consecutive buy in each epoch
-        for (uint256 i; i < tradeNum; i++) {
-            uint256 tokenBought;
-
-            if (i == tradeNum - 1) {
-                (tokenBought,) = buy(-int256(0.44467 ether));
-            } else {
-                (tokenBought,) = buy(-int256(0.44467 ether));
-                sellExactIn(tokenBought / 2);
-                buyExactOut(tokenBought / 2);
-            }
-
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            if (i == tradeNum - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    function test_buy_70emptyEpoch_20SameSizeUntilMaxProceed() public _deployLensQuoter {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        // no buys for N epochs
-        uint256 skipNumOfEpoch = 70;
-        uint256 tradeNum = 20;
-
-        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
-
-        // consecutive buy in each epoch
-        for (uint256 i; i < tradeNum; i++) {
-            uint256 tokenBought;
-
-            if (i == tradeNum - 1) {
-                (tokenBought,) = buy(-int256(0.667 ether));
-            } else {
-                (tokenBought,) = buy(-int256(0.667 ether));
-                sellExactIn(tokenBought / 2);
-                buyExactOut(tokenBought / 2);
-            }
-
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            if (i == tradeNum - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
-    }
-
-    function test_buy_EveryEpochUntilMaxProceed() public _deployLensQuoter {
-        // Go to starting time
-        vm.warp(hook.getStartingTime());
-
-        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
-
-        console.log("\n-------------- CURRENT CONFIG ------------------");
-        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
-        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
-        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
-        console.log("starting tick", hook.getStartingTick());
-        console.log("ending tick", hook.getEndingTick());
-        console.log("gamma", hook.getGamma());
-
-        uint256 tradeNum = 14;
-
-        // consecutive buy in each epoch
-        for (uint256 i; i < tradeNum; i++) {
-            uint256 tokenBought;
-
-            if (i == tradeNum - 1) {
-                (tokenBought,) = buy(-int256(1 ether));
-            } else {
-                (tokenBought,) = buy(-int256(1 ether));
-                sellExactIn(tokenBought / 2);
-                buyExactOut(tokenBought / 2);
-            }
-
-            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
-
-            uint160 sqrtPriceX96;
-            int24 tick;
-
-            if (i == tradeNum - 1) {
-                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
-            } else {
-                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
-                    IV4Quoter.QuoteExactSingleParams({
-                        poolKey: key,
-                        zeroForOne: !isToken0,
-                        exactAmount: 1,
-                        hookData: ""
-                    })
-                );
-            }
-            uint256 tokenPerOneETH = sqrtPriceX96;
-
-            console.log("\n-------------- SALE No. %d ------------------", i);
-            console.log("tick", tick);
-            console.log("token bought", tokenBought);
-            console.log("\n");
-            console.log("totalTokensSold / circulating supply", totalTokensSold);
-            console.log("totalProceeds", totalProceeds);
-            console.log("\n");
-            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
-            console.log("isEarlyExit", hook.earlyExit());
-            console.log("current epoch", hook.getCurrentEpoch());
-
-            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (tradeNum + i + 1)); // go to next epoch
-        }
-
-        vm.prank(hook.initializer());
-        hook.migrate(address(0xbeef));
-
-        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
-        console.log("ETH migrated: ", address(0xbeef).balance);
+        // NOTE: won't be enough proceed to migrate
+        // vm.prank(hook.initializer());
+        // hook.migrate(address(0xbeef));
+
+        // console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        // console.log("ETH migrated: ", address(0xbeef).balance);
     }
 }

--- a/test/shared/V4PocTest.sol
+++ b/test/shared/V4PocTest.sol
@@ -2,11 +2,669 @@
 pragma solidity ^0.8.24;
 
 import { Test, console } from "forge-std/Test.sol";
-import { BaseTest } from "test/shared/BaseTest.sol";
+import { StateLibrary } from "@v4-core/libraries/StateLibrary.sol";
+import { TickMath } from "@v4-core/libraries/TickMath.sol";
+import { PoolManager, IPoolManager } from "@v4-core/PoolManager.sol";
+import { IV4Quoter } from "@uniswap/v4-periphery/src/interfaces/IV4Quoter.sol";
+import { DopplerLensTest } from "test/unit/DopplerLens.t.sol";
+import { State } from "src/Doppler.sol";
 
-contract V4PocTest is BaseTest {
-    function test_v4_poc() public view {
-        // TODO: YOUR DOPPLER V4 POC HERE
-        console.log("hook starting time", hook.startingTime());
+interface IERC20 {
+    function balanceOf(
+        address account
+    ) external view returns (uint256);
+}
+
+using StateLibrary for IPoolManager;
+
+contract V4PocTest is DopplerLensTest {
+    function test_v4_emptyEpochForHalfSale_ThenBuy1ETH() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+        uint256 oriTokenBalance = IERC20(asset).balanceOf(address(this));
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+        console.log("\n");
+        console.log("numeraire ", numeraire);
+        console.log("asset ", asset);
+        console.log("isToken0 ", isToken0);
+        console.log("usingEth ", usingEth);
+
+        // no buys for N epochs
+        uint256 skipNumOfEpoch = 45; // 5 hrs
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
+
+        // buyExactOut(1);
+
+        // // quote the price
+        // (uint160 quotedSqrtPriceX96, int24 quotedTick) = lensQuoter.quoteDopplerLensData(
+        //     IV4Quoter.QuoteExactSingleParams({ poolKey: key, zeroForOne: !isToken0, exactAmount: 1, hookData: "" })
+        // );
+        // console.log("epoch 46 quoted sqrtPriceX96", quotedSqrtPriceX96);
+        // console.log("epoch 46 tick", quotedTick);
+
+        uint256 tokenBalB4 = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+
+        // get expected amount sold for the current epoch
+        // uint256 expectedAmountSold = hook.getExpectedAmountSoldWithEpochOffset(1);
+
+        // NOTE: CHANGE BUY AMOUNT HERE
+        (uint256 tokenBought,) = buy(-int256(1 ether));
+        // (uint256 tokenBought,) = buy(int256(expectedAmountSold));
+
+        uint256 tokenLeft = IERC20(asset).balanceOf(address(manager));
+        uint256 tokenLeftInHook = IERC20(asset).balanceOf(address(hook));
+        uint256 tokenBalAfter = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+        // uint256 ethLeft = address(manager).balance;
+        (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+        // (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(key.toId());
+        (uint160 sqrtPriceX96, int24 tick) = lensQuoter.quoteDopplerLensData(
+            IV4Quoter.QuoteExactSingleParams({ poolKey: key, zeroForOne: !isToken0, exactAmount: 1, hookData: "" })
+        );
+        uint256 tokenPerOneETH = sqrtPriceX96;
+
+        console.log("\n-------------- SALE ------------------");
+        console.log("tick", tick);
+        console.log("token left in hook", tokenLeftInHook);
+        console.log("token left in pool", tokenLeft);
+        console.log("token bal b4", tokenBalB4);
+        console.log("token bal af", tokenBalAfter);
+        console.log("token bought", tokenBought);
+        console.log("\n");
+        console.log("totalTokensSold / circulating supply", totalTokensSold);
+        console.log("totalProceeds", totalProceeds);
+        console.log("\n");
+        console.log("tokenPerOneETH / sqrtPriceX96", tokenPerOneETH);
+        console.log("current epoch", hook.getCurrentEpoch());
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + 1)); // go to next epoch
+    }
+
+    function test_v4_buyMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        int256 maximumProceeds = int256(hook.getMaximumProceeds());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+        uint256 oriTokenBalance = IERC20(asset).balanceOf(address(this));
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // quote the price
+        (uint160 quotedSqrtPriceX96, int24 quotedTick) = lensQuoter.quoteDopplerLensData(
+            IV4Quoter.QuoteExactSingleParams({ poolKey: key, zeroForOne: !isToken0, exactAmount: 1, hookData: "" })
+        );
+        console.log("\n");
+        console.log("quoted sqrtPriceX96", quotedSqrtPriceX96);
+        console.log("quoted tick", quotedTick);
+
+        uint256 tokenBalB4 = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+
+        (uint256 tokenBought,) = buy(-maximumProceeds);
+
+        uint256 tokenLeft = IERC20(asset).balanceOf(address(manager));
+        uint256 tokenLeftInHook = IERC20(asset).balanceOf(address(hook));
+        uint256 tokenBalAfter = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+        uint256 ethLeft = address(manager).balance;
+        (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+        (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(key.toId());
+
+        uint256 tokenPerOneETH = sqrtPriceX96;
+
+        console.log("\n-------------- SALE ------------------");
+        console.log("tick", tick);
+        console.log("token left in hook", tokenLeftInHook);
+        console.log("token left in pool", tokenLeft);
+        console.log("token bal b4", tokenBalB4);
+        console.log("token bal af", tokenBalAfter);
+        console.log("token bought", tokenBought);
+        console.log("eth left", ethLeft);
+        console.log("\n");
+        console.log("totalTokensSold / circulating supply", totalTokensSold);
+        console.log("totalProceeds", totalProceeds);
+        console.log("\n");
+        console.log("tokenPerOneETH/sqrtPriceX96", tokenPerOneETH);
+        console.log("isEarlyExit", hook.earlyExit());
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function testFuzz_buy_5EmptyEpoch_DiffSizeUntilMaxProceed(
+        uint256 buyEtherAmount,
+        uint256 sellEtherAmount,
+        uint256 buyBackEtherAmount
+    ) public _deployLensQuoter {
+        uint256 amount = 1.333 ether;
+        buyEtherAmount = bound(buyEtherAmount, amount, amount + 0.05 ether);
+        sellEtherAmount = bound(sellEtherAmount, 0.55 ether, amount / 2);
+        buyBackEtherAmount = bound(buyBackEtherAmount, 0.55 ether, amount / 2);
+
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+        uint256 oriTokenBalance = IERC20(asset).balanceOf(address(this));
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 skipNumOfEpoch = 5;
+        uint256 tradeNum = 10;
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
+
+        // consecutive trades in each epoch
+        for (uint256 i; i < tradeNum; i++) {
+            uint256 tokenBalB4 = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+
+            uint256 tokenBought;
+
+            (tokenBought,) = buy(-int256(buyEtherAmount));
+            sellExactIn(sellEtherAmount);
+            buyExactOut(buyBackEtherAmount);
+
+            uint256 tokenBalAfter = IERC20(asset).balanceOf(address(this)) - oriTokenBalance;
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == tradeNum - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bal b4", tokenBalB4);
+            console.log("token bal af", tokenBalAfter);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_45emptyEpoch_45SameSizeUntilMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 totalEpochs = 90;
+        uint256 halfOfEpoch = totalEpochs / 2;
+        uint256 maxProceed = 13_333e15;
+        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
+
+        console.log("buyEthAmount", buyEthAmount);
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < halfOfEpoch; i++) {
+            uint256 tokenBought;
+
+            (tokenBought,) = buy(-int256(buyEthAmount));
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == halfOfEpoch - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_60sPerEpoch_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 totalEpochs = 360;
+        uint256 halfOfEpoch = totalEpochs / 2;
+        uint256 maxProceed = 13_333e15;
+        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
+
+        // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < halfOfEpoch; i++) {
+            uint256 tokenBought;
+
+            // if (i == halfOfEpoch - 1) {
+            (tokenBought,) = buy(-int256(buyEthAmount));
+
+            // } else {
+            //     (tokenBought,) = buy(-int256(0.0740556 ether));
+            //     sellExactIn(tokenBought / 2);
+            //     buyExactOut(tokenBought / 2);
+            // }
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == halfOfEpoch - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_24hrSale_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 totalEpochs = 216;
+        uint256 halfOfEpoch = totalEpochs / 2;
+        uint256 maxProceed = 13_333e15;
+        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
+
+        // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < halfOfEpoch; i++) {
+            uint256 tokenBought;
+
+            (tokenBought,) = buy(-int256(buyEthAmount));
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == halfOfEpoch - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_10hrSale_50ETHProceed_100sPerEpoch_HalfEmptyEpoch_HalfSameSizeUntilMaxProceed()
+        public
+        _deployLensQuoter
+    {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 totalEpochs = 360;
+        uint256 halfOfEpoch = totalEpochs / 2;
+        uint256 maxProceed = 50 ether;
+        uint256 buyEthAmount = maxProceed / halfOfEpoch + 1;
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * halfOfEpoch);
+
+        // vm.warp(hook.getStartingTime() + hook.getEpochLength()); // go to next epoch
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < halfOfEpoch; i++) {
+            uint256 tokenBought;
+
+            (tokenBought,) = buy(-int256(buyEthAmount));
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            // if (i == halfOfEpoch - 1) {
+            (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            // } else {
+            //     (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+            //         IV4Quoter.QuoteExactSingleParams({
+            //             poolKey: key,
+            //             zeroForOne: !isToken0,
+            //             exactAmount: 1,
+            //             hookData: ""
+            //         })
+            //     );
+            // }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (halfOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_60emptyEpoch_30SameSizeUntilMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 skipNumOfEpoch = 60;
+        uint256 tradeNum = 30;
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < tradeNum; i++) {
+            uint256 tokenBought;
+
+            if (i == tradeNum - 1) {
+                (tokenBought,) = buy(-int256(0.44467 ether));
+            } else {
+                (tokenBought,) = buy(-int256(0.44467 ether));
+                sellExactIn(tokenBought / 2);
+                buyExactOut(tokenBought / 2);
+            }
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == tradeNum - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
+    }
+
+    function test_buy_70emptyEpoch_20SameSizeUntilMaxProceed() public _deployLensQuoter {
+        // Go to starting time
+        vm.warp(hook.getStartingTime());
+
+        (uint160 oriSqrtPriceX96,,,) = manager.getSlot0(key.toId());
+
+        console.log("\n-------------- CURRENT CONFIG ------------------");
+        console.log("ori token left in hook", IERC20(asset).balanceOf(address(hook)));
+        console.log("ori token left in pool", IERC20(asset).balanceOf(address(manager)));
+        console.log("ori sqrtPriceX96", oriSqrtPriceX96);
+        console.log("starting tick", hook.getStartingTick());
+        console.log("ending tick", hook.getEndingTick());
+        console.log("gamma", hook.getGamma());
+
+        // no buys for N epochs
+        uint256 skipNumOfEpoch = 70;
+        uint256 tradeNum = 20;
+
+        vm.warp(hook.getStartingTime() + hook.getEpochLength() * skipNumOfEpoch);
+
+        // consecutive buy in each epoch
+        for (uint256 i; i < tradeNum; i++) {
+            uint256 tokenBought;
+
+            if (i == tradeNum - 1) {
+                (tokenBought,) = buy(-int256(0.667 ether));
+            } else {
+                (tokenBought,) = buy(-int256(0.667 ether));
+                sellExactIn(tokenBought / 2);
+                buyExactOut(tokenBought / 2);
+            }
+
+            (,, uint256 totalTokensSold, uint256 totalProceeds,,) = hook.state();
+
+            uint160 sqrtPriceX96;
+            int24 tick;
+
+            if (i == tradeNum - 1) {
+                (sqrtPriceX96, tick,,) = manager.getSlot0(key.toId());
+            } else {
+                (sqrtPriceX96, tick) = lensQuoter.quoteDopplerLensData(
+                    IV4Quoter.QuoteExactSingleParams({
+                        poolKey: key,
+                        zeroForOne: !isToken0,
+                        exactAmount: 1,
+                        hookData: ""
+                    })
+                );
+            }
+            uint256 tokenPerOneETH = sqrtPriceX96;
+
+            console.log("\n-------------- SALE No. %d ------------------", i);
+            console.log("tick", tick);
+            console.log("token bought", tokenBought);
+            console.log("\n");
+            console.log("totalTokensSold / circulating supply", totalTokensSold);
+            console.log("totalProceeds", totalProceeds);
+            console.log("\n");
+            console.log("token / ETH (sqrtPriceX96)", tokenPerOneETH);
+            console.log("isEarlyExit", hook.earlyExit());
+            console.log("current epoch", hook.getCurrentEpoch());
+
+            vm.warp(hook.getStartingTime() + hook.getEpochLength() * (skipNumOfEpoch + i + 1)); // go to next epoch
+        }
+
+        vm.prank(hook.initializer());
+        hook.migrate(address(0xbeef));
+
+        console.log("\nToken migrated: ", IERC20(asset).balanceOf(address(0xbeef)));
+        console.log("ETH migrated: ", address(0xbeef).balance);
     }
 }


### PR DESCRIPTION
This PR is to expand the foundry test suite to include test cases for running simulations for Doppler v4 i.e. to test how the price will react with different params(ticks, gamma, max proceed etc) set in `BaseTest.sol` - the tests include loggings to keep track of data e.g. current sqrtPriceX96, total proceeds, total circulating supply of tokens during each trade

Some simulation scenarios include:
- after certain epochs without any trades then consecutive buys for a fixed number of epochs 
- buys with a fixed amount until max proceed reached
- buys within a fixed number of epochs until max proceed reached

This provides an easier way for other integrators to simulate Doppler v4 with their desired parameter sets.