### PR TITLE
test: avoid unnecessary call in salt mining

### DIFF
--- a/test/shared/AirlockMiner.sol
+++ b/test/shared/AirlockMiner.sol
@@ -105,8 +105,10 @@ function mineV4(
         )
     );
 
+    address deployer = address(params.poolInitializer.deployer());
+
     for (uint256 salt; salt < 200_000; ++salt) {
-        address hook = computeCreate2Address(bytes32(salt), dopplerInitHash, address(params.poolInitializer.deployer()));
+        address hook = computeCreate2Address(bytes32(salt), dopplerInitHash, deployer);
         address asset = computeCreate2Address(bytes32(salt), tokenInitHash, address(params.tokenFactory));
 
         if (


### PR DESCRIPTION
This is a simple PR to prevent unnecessary call for `deployer()` in salt mining which results in logs flooding during test.