### PR TITLE
fix: reset price when reaching limit

### DIFF
--- a/test/invariant/DopplerHandler.sol
+++ b/test/invariant/DopplerHandler.sol
@@ -181,7 +181,7 @@ contract DopplerHandler is Test {
             } else if (selector == InvalidSwapAfterMaturityInsufficientProceeds.selector) {
                 revert("invalid swap after maturity");
             } else if (selector == Pool.PriceLimitAlreadyExceeded.selector) {
-                // revert("price limit already exceeded");
+                revert("price limit already exceeded");
             } else {
                 revert("Unknown error");
             }


### PR DESCRIPTION
# Description

Fixes the `PriceLimitReached` error showing up after all the asset tokens were bought from the pool. This is due to the `PoolManager` contract looking for asset tokens to sell from the current tick up to the `MAX_TICK` (or `MIN_TICK`), and thus pushing the price to its limit. This resulted in freezing the auction since the price couldn't be increased during the next rebalancing.

The fix here is quite simple: if all the asset tokens were sold, we manually move back the current tick from the `MAX_TICK` or `MIN_TICK`, to the top of the higher price discovery slug.