### PR TITLE
fix: use empty address for v4 pools to prevent dead address collision

### DIFF
--- a/src/UniswapV4Migrator.sol
+++ b/src/UniswapV4Migrator.sol
@@ -76,6 +76,9 @@ contract UniswapV4Migrator is ILiquidityMigrator, ImmutableAirlock {
     /// @notice The dead address used for no-op governance
     address public constant DEAD_ADDRESS = address(0xdead);
 
+    /// @notice The empty address used to indicate no pool exists (bc v4 is a singleton)
+    address public constant EMPTY_ADDRESS = address(0x0);
+
     /// @notice Mapping of asset pairs to their respective asset data
     mapping(address token0 => mapping(address token1 => AssetData data)) public getAssetData;
 
@@ -141,7 +144,7 @@ contract UniswapV4Migrator is ILiquidityMigrator, ImmutableAirlock {
         getAssetData[Currency.unwrap(poolKey.currency0)][Currency.unwrap(poolKey.currency1)] =
             AssetData({ poolKey: poolKey, lockDuration: lockDuration, beneficiaries: beneficiaries });
 
-        return DEAD_ADDRESS;
+        return EMPTY_ADDRESS; // v4 pools are represented by their PoolKey, so we return an empty address
     }
 
     /// @inheritdoc ILiquidityMigrator


### PR DESCRIPTION
## Summary

This PR changes the return value for V4 pool creation from `DEAD_ADDRESS` (0xdead) to `EMPTY_ADDRESS` (0x0) to prevent conflicts with the dead address used by no-op governance.

## Context

In Uniswap V4, pools don't have individual addresses - they exist within the singleton PoolManager and are identified by their PoolKey. The migrator was returning `DEAD_ADDRESS` (0xdead) as a placeholder, but this conflicts with the same address used for no-op governance purposes elsewhere in the protocol.

## Changes

- Added `EMPTY_ADDRESS` constant set to `address(0x0)`
- Changed the return value of `registerPool()` from `DEAD_ADDRESS` to `EMPTY_ADDRESS`
- Added a comment explaining that V4 pools are represented by their PoolKey

## Impact

This change prevents potential conflicts and confusion by using a distinct address (0x0) to indicate "no pool address" for V4 pools, keeping the dead address (0xdead) reserved exclusively for no-op governance use.