### PR TITLE
test: add BasicMultisig

### DIFF
--- a/test/shared/BasicMultisig.sol
+++ b/test/shared/BasicMultisig.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/// @notice A very basic multisig for testing purposes, do not use in production :)
+contract BasicMultisig {
+    mapping(address => bool) public isSigner;
+
+    modifier onlySigner() {
+        require(isSigner[msg.sender], "Not a signer");
+        _;
+    }
+
+    constructor(
+        address[] memory signers
+    ) {
+        for (uint256 i; i < signers.length; ++i) {
+            require(signers[i] != address(0), "Signer cannot be zero address");
+            isSigner[signers[i]] = true;
+        }
+    }
+
+    function execute(address to, bytes calldata data) external payable onlySigner {
+        (bool success,) = to.call{ value: msg.value }(data);
+        require(success, "Execution failed");
+    }
+
+    function addSigner(
+        address newSigner
+    ) external onlySigner {
+        require(newSigner != address(0), "New signer cannot be zero address");
+        require(!isSigner[newSigner], "Already a signer");
+        isSigner[newSigner] = true;
+    }
+}


### PR DESCRIPTION
## Description

Add a very simple multisig contract for testing purposing, mainly to whitelist modules on testnets.

## Motivation

We needed a better workflow than having a unique EOA whitelisting modules on testnets!

## Changes

- New `BasicMultisig` contract
