### PR TITLE
Update housekeeping github action permissions

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -9,6 +9,9 @@ concurrency:
   group: housekeeping-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   copy-file:
     runs-on: ubuntu-latest
@@ -17,6 +20,7 @@ jobs:
       - name: Checkout Contracts repository
         uses: actions/checkout@v4
         with:
+          ref: main
           path: contracts
 
       - name: Checkout Docs repository


### PR DESCRIPTION
## Description

Added contents: write permission to the housekeeping workflow to fix push failures when committing generated deployment documentation back to the contracts repository.

## Motivation

The workflow was failing with a 403 error when trying to push generated deployment files back to the contracts repo. GitHub changed the default GITHUB_TOKEN permissions to read-only for security, so workflows now need to explicitly request write access.

## Changes

Added permissions: contents: write to .github/workflows/housekeeping.yml to grant the workflow permission to push commits to the repository
