### PR TITLE
feat: DopplerLensQuoter deployment script

### DIFF
--- a/deployments.config.toml
+++ b/deployments.config.toml
@@ -33,6 +33,7 @@ streamable_fees_locker_v2 = "0xcE3212e6536F33cD6fbFEE265224131353Ca3D47"
 doppler_hook_migrator = "0x1E40b0875DDa35f41E15cFB475403859B8c860c4"
 rehype_doppler_hook_migrator = "0xea95DfdF69B90c65C827070852F7039D6aF6Dd7b"
 governance_factory = "0x9F309D79BEe3E8b2f56FaCF74b7195Df176c8F61"
+uniswap_v4_state_view = "0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227"
 
 [11155111]
 endpoint_url = "${ETH_SEPOLIA_RPC_URL}"
@@ -98,6 +99,8 @@ top_up_distributor = "0x435312320C0330B1999746753551CdFbD83aD814"
 streamable_fees_locker_v2 = "0xcE3212e6536F33cD6fbFEE265224131353Ca3D47"
 doppler_hook_migrator = "0x1E40b0875DDa35f41E15cFB475403859B8c860c4"
 rehype_doppler_hook_migrator = "0xea95DfdF69B90c65C827070852F7039D6aF6Dd7b"
+uniswap_v4_state_view = "0xA3c0c9b65baD0b08107Aa264b0f3dB444b867A71"
+doppler_lens_quoter = "0x43d0D97EC9241A8F05A264f94B82A1d2E600f2B3"
 
 [130]
 endpoint_url = "${UNICHAIN_MAINNET_RPC_URL}"
@@ -138,6 +141,7 @@ airlock_multisig = "0x21E2ce70511e4FE542a97708e89520471DAa7A66"
 streamable_fees_locker_v2 = "0xcE3212e6536F33cD6fbFEE265224131353Ca3D47"
 doppler_hook_migrator = "0x1E40b0875DDa35f41E15cFB475403859B8c860c4"
 rehype_doppler_hook_migrator = "0x82d5E22911fbbCB8d3e45812d74eE6203c5824e0"
+uniswap_v4_state_view = "0x77395F3b2E73aE90843717371294fa97cC419D64"
 
 [4326]
 endpoint_url = "${MEGAETH_MAINNET_RPC_URL}"
@@ -193,6 +197,8 @@ decay_multicurve_initializer = "0xD59cE43E53D69F190E15d9822Fb4540dCcc91178"
 streamable_fees_locker_v2 = "0xcE3212e6536F33cD6fbFEE265224131353Ca3D47"
 doppler_hook_migrator = "0x1E40b0875DDa35f41E15cFB475403859B8c860c4"
 rehype_doppler_hook_migrator = "0xea95DfdF69B90c65C827070852F7039D6aF6Dd7b"
+uniswap_v4_state_view = "0x571291b572ed32ce6751a2Cb2486EbEe8DEfB9B4"
+doppler_lens_quoter = "0x4a8d81Db741248a36D9eb3bc6eF648Bf798B47a7"
 
 [1301]
 endpoint_url = "${UNICHAIN_SEPOLIA_RPC_URL}"

--- a/script/DeployDopplerLensQuoter.s.sol
+++ b/script/DeployDopplerLensQuoter.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { Config } from "forge-std/Config.sol";
+import { TypeKind, Variable } from "forge-std/LibVariable.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/ChainIds.sol";
+import { ICreateX } from "script/ICreateX.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { DopplerLensQuoter } from "src/lens/DopplerLens.sol";
+
+contract DeployDopplerLensQuoterScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.MONAD_MAINNET;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address createX = config.get("create_x").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+        address stateView = config.get("uniswap_v4_state_view").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(DopplerLensQuoter).name);
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address dopplerLensQuoter = ICreateX(createX)
+            .deployCreate3(
+                salt, abi.encodePacked(type(DopplerLensQuoter).creationCode, abi.encode(poolManager, stateView))
+            );
+        require(dopplerLensQuoter == expectedAddress, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        // Only set the config if a broadcast has occurred
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) config.set("doppler_lens_quoter", dopplerLensQuoter);
+        console.log(
+            "DopplerLensQuoter was deployed to",
+            LibString.toHexString(uint256(uint160(dopplerLensQuoter))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}


### PR DESCRIPTION
## Description

Add deployment script for `DopplerLensQuoter`.

## Motivation

`DopplerLensQuoter` is a contract used by our indexer for certain functions on Base/Base Sepolia. I was going to get this deployed to Ethereum and Monad, but was made aware that our new indexer will not need this. Thus, this PR only includes the new deployment script in case the contracts are ever needed, but does not include any deployment logs. I also want to include the script as it provides an example design I want to use elsewhere when rebuilding scripts.

## Changes

- `deployments.config.toml`
  - Updated for existing deployments and related Uniswap contracts.
- `script/DeployDopplerLensQuoter.s.sol`
  - New deployment script, in case it is ever useful