### PR TITLE
fix: guard int128 to uint128 cast in SwapRestrictorDopplerHook

### DIFF
--- a/src/dopplerHooks/SwapRestrictorDopplerHook.sol
+++ b/src/dopplerHooks/SwapRestrictorDopplerHook.sol
@@ -55,7 +55,9 @@ contract SwapRestrictorDopplerHook is BaseDopplerHookInitializer {
 
         // This condition checks if the asset token is being bought
         if (params.zeroForOne != isToken0) {
-            uint256 amountRequested = isToken0 ? uint128(balanceDelta.amount0()) : uint128(balanceDelta.amount1());
+            int128 assetDelta = isToken0 ? balanceDelta.amount0() : balanceDelta.amount1();
+            require(assetDelta > 0, "SwapRestrictor: non-positive asset delta");
+            uint256 amountRequested = uint256(uint128(assetDelta));
             PoolId poolId = key.toId();
             require(
                 amountLeftOf[poolId][sender] >= amountRequested,


### PR DESCRIPTION
## Summary

- `SwapRestrictorDopplerHook._onSwap` casts `balanceDelta.amount0()` (int128) directly to `uint128`
- Negative values wrap to ~2^128, making `amountRequested` enormous and the `amountLeftOf` restriction check always pass
- Extracts the raw `int128`, requires it is positive, then casts safely

## Found by

AntFleet two-model consensus review (Claude Opus 4.7 + GPT-5)
Benchmark: https://github.com/AntFleet/bench-doppler/pull/2

## Test plan

- [ ] Verify swap restriction still enforces limits on valid positive deltas
- [ ] Confirm revert on negative asset delta scenarios