### PR TITLE
[EVM-44] feat: add DopplerDeployer contract and protected files workflow

### DIFF
--- a/.github/protected-files.txt
+++ b/.github/protected-files.txt
@@ -1,0 +1,2 @@
+# One repository-relative path per line. Lines starting with # are ignored.
+src/DopplerDeployer.sol

--- a/.github/workflows/protected-files.yml
+++ b/.github/workflows/protected-files.yml
@@ -1,0 +1,96 @@
+name: Protected files
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: protected-files-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Block protected file changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Check protected files
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+
+            const blocklistPath = '.github/protected-files.txt';
+            const parseBlocklist = (contents) => contents
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line && !line.startsWith('#'));
+
+            const blocklist = parseBlocklist(fs.readFileSync(blocklistPath, 'utf8'));
+            const protectedFiles = new Set(blocklist);
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const blocked = [...new Set(changedFiles
+              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean))
+              .filter((filename) => protectedFiles.has(filename)))]
+              .sort();
+
+            const pullRequest = context.payload.pull_request;
+            let headBlocklistResponse;
+            try {
+              headBlocklistResponse = await github.rest.repos.getContent({
+                owner: pullRequest.head.repo.owner.login,
+                repo: pullRequest.head.repo.name,
+                path: blocklistPath,
+                ref: pullRequest.head.sha,
+              });
+            } catch (error) {
+              core.setFailed(`Unable to read ${blocklistPath} from the pull request head: ${error.message}`);
+              return;
+            }
+
+            if (!headBlocklistResponse.data.content) {
+              core.setFailed(`Expected ${blocklistPath} to be a file in the pull request head.`);
+              return;
+            }
+
+            const headBlocklistContent = Buffer.from(headBlocklistResponse.data.content, 'base64').toString();
+            const headBlocklist = new Set(parseBlocklist(headBlocklistContent));
+            const removedEntries = blocklist
+              .filter((filename) => !headBlocklist.has(filename))
+              .sort();
+
+            for (const filename of removedEntries) {
+              core.error(`Protected file entry ${filename} cannot be removed from ${blocklistPath}.`);
+            }
+
+            if (blocked.length === 0) {
+              core.info('No protected files changed.');
+            } else {
+              for (const filename of blocked) {
+                core.error(`Changes to ${filename} are blocked by ${blocklistPath}.`);
+              }
+            }
+
+            if (blocked.length > 0 || removedEntries.length > 0) {
+              core.setFailed('Protected file policy failed.');
+            }

--- a/src/DopplerDeployer.sol
+++ b/src/DopplerDeployer.sol
@@ -47,33 +47,45 @@ contract DopplerDeployer is OwnableRoles {
     /*                      ROLE MANAGEMENT                       */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    /// @notice Grants admin privileges to an address.
+    /// @notice Grants admin privileges to each address.
     /// @dev Admins can add and remove deployers, and perform calls and deployments.
-    function addAdmin(address admin) external onlyOwner {
-        _setRoles(admin, _ROLE_ADMIN);
-        emit AdminAdded(admin);
+    function addAdmins(address[] calldata admins) external onlyOwner {
+        for (uint256 i; i < admins.length; ++i) {
+            address admin = admins[i];
+            _setRoles(admin, _ROLE_ADMIN);
+            emit AdminAdded(admin);
+        }
     }
 
-    /// @notice Removes all roles from an admin address.
-    function removeAdmin(address admin) external onlyOwner {
-        _setRoles(admin, 0);
-        emit AdminRemoved(admin);
+    /// @notice Removes all roles from each admin address.
+    function removeAdmins(address[] calldata admins) external onlyOwner {
+        for (uint256 i; i < admins.length; ++i) {
+            address admin = admins[i];
+            _setRoles(admin, 0);
+            emit AdminRemoved(admin);
+        }
     }
 
-    /// @notice Grants deployer privileges to an address.
-    /// @dev The target must not already have a role and cannot be the caller.
-    function addDeployer(address deployer) external onlyRolesOrOwner(_ROLE_ADMIN) {
-        require(rolesOf(deployer) == 0, RoleAlreadyAssigned());
-        require(deployer != address(0) && deployer != msg.sender, InvalidDeployer());
-        _grantRoles(deployer, _ROLE_DEPLOYER);
-        emit DeployerAdded(msg.sender, deployer);
+    /// @notice Grants deployer privileges to each address.
+    /// @dev Each target must not already have a role and cannot be the caller.
+    function addDeployers(address[] calldata deployers) external onlyRolesOrOwner(_ROLE_ADMIN) {
+        for (uint256 i; i < deployers.length; ++i) {
+            address deployer = deployers[i];
+            require(rolesOf(deployer) == 0, RoleAlreadyAssigned());
+            require(deployer != address(0) && deployer != msg.sender, InvalidDeployer());
+            _grantRoles(deployer, _ROLE_DEPLOYER);
+            emit DeployerAdded(msg.sender, deployer);
+        }
     }
 
-    /// @notice Removes deployer privileges from an address.
-    function removeDeployer(address deployer) external onlyRolesOrOwner(_ROLE_ADMIN) {
-        require(rolesOf(deployer) == _ROLE_DEPLOYER, InvalidDeployer());
-        _removeRoles(deployer, _ROLE_DEPLOYER);
-        emit DeployerRemoved(msg.sender, deployer);
+    /// @notice Removes deployer privileges from each address.
+    function removeDeployers(address[] calldata deployers) external onlyRolesOrOwner(_ROLE_ADMIN) {
+        for (uint256 i; i < deployers.length; ++i) {
+            address deployer = deployers[i];
+            require(rolesOf(deployer) == _ROLE_DEPLOYER, InvalidDeployer());
+            _removeRoles(deployer, _ROLE_DEPLOYER);
+            emit DeployerRemoved(msg.sender, deployer);
+        }
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/src/DopplerDeployer.sol
+++ b/src/DopplerDeployer.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { OwnableRoles } from "solady/auth/OwnableRoles.sol";
+
+/// @title DopplerDeployer
+/// @notice Permissioned wrapper around CreateX for deterministic Doppler protocol deployments.
+contract DopplerDeployer is OwnableRoles {
+    /// @notice Batch call ETH value did not equal the supplied per-call values.
+    error PaymentMismatch(uint256 actual, uint256 expected);
+    /// @notice Deployed address differed from the caller-supplied expected address.
+    error AddressMismatch(address actual, address expected);
+    /// @notice A forwarded call reverted.
+    error ExecutionFailed();
+    /// @notice Deployer role target is invalid for the requested role update.
+    error InvalidDeployer();
+    /// @notice A role assignment was attempted for an address that already has a role.
+    error RoleAlreadyAssigned();
+    /// @notice Batch execution arrays must have identical lengths.
+    error ArrayLengthsMismatch();
+
+    /// @notice Emitted when the owner grants admin privileges.
+    event AdminAdded(address admin);
+    /// @notice Emitted when the owner removes admin privileges.
+    event AdminRemoved(address admin);
+    /// @notice Emitted when an admin or owner grants deployer privileges.
+    event DeployerAdded(address indexed admin, address deployer);
+    /// @notice Emitted when an admin or owner removes deployer privileges.
+    event DeployerRemoved(address indexed admin, address deployer);
+    /// @notice Emitted after a successful CreateX deployment.
+    event Deployed(address indexed deployer, address deployed);
+
+    /// @notice Canonical CreateX factory used for deployments and address derivation.
+    ICreateX public constant CreateX = ICreateX(0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed);
+
+    uint256 internal constant _ROLE_ADMIN = _ROLE_0;
+    uint256 internal constant _ROLE_DEPLOYER = _ROLE_1;
+    uint256 internal constant _ROLE_AUTHORIZED = _ROLE_0 | _ROLE_1;
+
+    /// @param newOwner Initial contract owner.
+    constructor(address newOwner) {
+        _initializeOwner(newOwner);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      ROLE MANAGEMENT                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Grants admin privileges to an address.
+    /// @dev Admins can add and remove deployers, and perform calls and deployments.
+    function addAdmin(address admin) external onlyOwner {
+        _setRoles(admin, _ROLE_ADMIN);
+        emit AdminAdded(admin);
+    }
+
+    /// @notice Removes all roles from an admin address.
+    function removeAdmin(address admin) external onlyOwner {
+        _setRoles(admin, 0);
+        emit AdminRemoved(admin);
+    }
+
+    /// @notice Grants deployer privileges to an address.
+    /// @dev The target must not already have a role and cannot be the caller.
+    function addDeployer(address deployer) external onlyRolesOrOwner(_ROLE_ADMIN) {
+        require(rolesOf(deployer) == 0, RoleAlreadyAssigned());
+        require(deployer != address(0) && deployer != msg.sender, InvalidDeployer());
+        _grantRoles(deployer, _ROLE_DEPLOYER);
+        emit DeployerAdded(msg.sender, deployer);
+    }
+
+    /// @notice Removes deployer privileges from an address.
+    function removeDeployer(address deployer) external onlyRolesOrOwner(_ROLE_ADMIN) {
+        require(rolesOf(deployer) == _ROLE_DEPLOYER, InvalidDeployer());
+        _removeRoles(deployer, _ROLE_DEPLOYER);
+        emit DeployerRemoved(msg.sender, deployer);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       SALT FUNCTIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Generates a deployer-keyed, non-chain-specific CreateX salt.
+    /// @dev This is a convenience helper, externally generated valid CreateX salts are also supported.
+    function generateSalt(string memory name, uint256 version) external view returns (bytes32) {
+        return bytes32(uint256(uint160(address(this)))) << 96 | keccak256(abi.encode(name, version)) >> 168;
+    }
+
+    /// @notice Computes the guarded salt CreateX will use for an explicit salt deployment.
+    function computeGuardedSalt(bytes32 salt) external view returns (bytes32) {
+        return _guardSalt(salt);
+    }
+
+    /// @notice Computes the Create2 address for a salt and init code hash using CreateX guard rules.
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address) {
+        return CreateX.computeCreate2Address(_guardSalt(salt), initCodeHash);
+    }
+
+    /// @notice Computes the Create3 address for a salt using CreateX guard rules.
+    function computeCreate3Address(bytes32 salt) external view returns (address) {
+        return CreateX.computeCreate3Address(_guardSalt(salt));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   EXECUTION & DEPLOYMENT                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Executes a single call as this contract.
+    /// @return Forwarded return data from the target call.
+    function execute(
+        address target,
+        bytes calldata data
+    ) external payable onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (bytes memory) {
+        (bool success, bytes memory result) = target.call{ value: msg.value }(data);
+        require(success, ExecutionFailed());
+        return result;
+    }
+
+    /// @notice Executes multiple calls as this contract.
+    /// @return results Forwarded return data for each target call.
+    function execute(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata data
+    ) external payable onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (bytes[] memory) {
+        require(targets.length == values.length && targets.length == data.length, ArrayLengthsMismatch());
+
+        uint256 totalValue;
+        bytes[] memory results = new bytes[](targets.length);
+        for (uint256 i; i < targets.length; ++i) {
+            bool success;
+            (success, results[i]) = targets[i].call{ value: values[i] }(data[i]);
+            require(success, ExecutionFailed());
+            unchecked {
+                totalValue += values[i];
+            }
+        }
+
+        require(msg.value == totalValue, PaymentMismatch(msg.value, totalValue));
+        return results;
+    }
+
+    /// @notice Deploys init code through CreateX Create2.
+    /// @return deployed Address of the deployed contract.
+    function deployCreate2(
+        bytes32 salt,
+        bytes memory initCode
+    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate2(salt, initCode);
+        emit Deployed(msg.sender, deployed);
+        return deployed;
+    }
+
+    /// @notice Deploys init code through CreateX Create2 and checks the expected address.
+    /// @return deployed Address of the deployed contract.
+    function deployCreate2(
+        bytes32 salt,
+        bytes memory initCode,
+        address expected
+    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate2(salt, initCode);
+        require(deployed == expected, AddressMismatch(deployed, expected));
+        emit Deployed(msg.sender, deployed);
+        return deployed;
+    }
+
+    /// @notice Deploys init code through CreateX Create3.
+    /// @return deployed Address of the deployed contract.
+    function deployCreate3(
+        bytes32 salt,
+        bytes memory initCode
+    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate3(salt, initCode);
+        emit Deployed(msg.sender, deployed);
+        return deployed;
+    }
+
+    /// @notice Deploys init code through CreateX Create3 and checks the expected address.
+    /// @return deployed Address of the deployed contract.
+    function deployCreate3(
+        bytes32 salt,
+        bytes memory initCode,
+        address expected
+    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate3(salt, initCode);
+        require(deployed == expected, AddressMismatch(deployed, expected));
+        emit Deployed(msg.sender, deployed);
+        return deployed;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      INTERNAL HELPERS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Hashes two words using the same packed memory layout as CreateX.
+    function _efficientHash(bytes32 a, bytes32 b) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            hash := keccak256(0x00, 0x40)
+        }
+    }
+
+    /// @dev Mirrors CreateX guarded salts for explicit salt calls, salt validation happens in CreateX.
+    function _guardSalt(bytes32 salt) internal view returns (bytes32) {
+        address senderBytes = address(bytes20(salt));
+        bytes1 redeployProtectionFlag = salt[20];
+
+        if (senderBytes == address(this)) {
+            if (redeployProtectionFlag == hex"00") {
+                return _efficientHash({ a: bytes32(uint256(uint160(address(this)))), b: salt });
+            }
+            if (redeployProtectionFlag == hex"01") {
+                return keccak256(abi.encode(address(this), block.chainid, salt));
+            }
+        } else if (senderBytes == address(0) && redeployProtectionFlag == hex"01") {
+            return _efficientHash({ a: bytes32(block.chainid), b: salt });
+        }
+
+        return keccak256(abi.encode(salt));
+    }
+}

--- a/src/DopplerDeployer.sol
+++ b/src/DopplerDeployer.sol
@@ -94,7 +94,7 @@ contract DopplerDeployer is OwnableRoles {
 
     /// @notice Generates a deployer-keyed, non-chain-specific CreateX salt.
     /// @dev This is a convenience helper, externally generated valid CreateX salts are also supported.
-    function generateSalt(string memory name, uint256 version) external view returns (bytes32) {
+    function generateSalt(string calldata name, uint256 version) external view returns (bytes32) {
         return bytes32(uint256(uint160(address(this)))) << 96 | keccak256(abi.encode(name, version)) >> 168;
     }
 
@@ -156,7 +156,7 @@ contract DopplerDeployer is OwnableRoles {
     /// @return deployed Address of the deployed contract.
     function deployCreate2(
         bytes32 salt,
-        bytes memory initCode
+        bytes calldata initCode
     ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
         address deployed = CreateX.deployCreate2(salt, initCode);
         emit Deployed(msg.sender, deployed);
@@ -167,7 +167,7 @@ contract DopplerDeployer is OwnableRoles {
     /// @return deployed Address of the deployed contract.
     function deployCreate2(
         bytes32 salt,
-        bytes memory initCode,
+        bytes calldata initCode,
         address expected
     ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
         address deployed = CreateX.deployCreate2(salt, initCode);
@@ -180,7 +180,7 @@ contract DopplerDeployer is OwnableRoles {
     /// @return deployed Address of the deployed contract.
     function deployCreate3(
         bytes32 salt,
-        bytes memory initCode
+        bytes calldata initCode
     ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
         address deployed = CreateX.deployCreate3(salt, initCode);
         emit Deployed(msg.sender, deployed);
@@ -191,7 +191,7 @@ contract DopplerDeployer is OwnableRoles {
     /// @return deployed Address of the deployed contract.
     function deployCreate3(
         bytes32 salt,
-        bytes memory initCode,
+        bytes calldata initCode,
         address expected
     ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
         address deployed = CreateX.deployCreate3(salt, initCode);

--- a/test/unit/DopplerDeployer.t.sol
+++ b/test/unit/DopplerDeployer.t.sol
@@ -1,0 +1,651 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Ownable } from "@solady/auth/Ownable.sol";
+import { ICreateX } from "createx/ICreateX.sol";
+import { Test } from "forge-std/Test.sol";
+import { DopplerDeployer } from "src/DopplerDeployer.sol";
+
+contract DopplerDeployerTest is Test {
+    event RolesUpdated(address indexed user, uint256 indexed roles);
+    event AdminAdded(address admin);
+    event AdminRemoved(address admin);
+    event DeployerAdded(address indexed admin, address deployer);
+    event DeployerRemoved(address indexed admin, address deployer);
+    event Deployed(address indexed deployer, address deployed);
+
+    address internal constant CREATEX = 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed;
+    uint256 internal constant ROLE_ADMIN = 1;
+    uint256 internal constant ROLE_DEPLOYER = 2;
+
+    address internal owner = makeAddr("owner");
+    address internal admin = makeAddr("admin");
+    address internal authorizedDeployer = makeAddr("authorizedDeployer");
+    address internal stranger = makeAddr("stranger");
+
+    DopplerDeployer internal deployer;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           SETUP                            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function setUp() public {
+        _etchCreateX();
+        deployer = new DopplerDeployer(owner);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CONSTRUCTOR                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Constructor records the supplied owner.
+    function test_constructor_setsOwner() public view {
+        assertEq(deployer.owner(), owner);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      ROLE MANAGEMENT                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Only the owner can grant admin role and emit the expected events.
+    function test_addAdmin_ownerOnly_setsRoleAndEmits() public {
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, ROLE_ADMIN);
+        vm.expectEmit(false, false, false, true, address(deployer));
+        emit AdminAdded(admin);
+
+        vm.prank(owner);
+        deployer.addAdmin(admin);
+
+        assertEq(deployer.rolesOf(admin), ROLE_ADMIN);
+        assertTrue(deployer.hasAnyRole(admin, ROLE_ADMIN));
+    }
+
+    /// @notice Non-owners cannot grant admin role.
+    function test_addAdmin_revertUnauthorized() public {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.addAdmin(admin);
+    }
+
+    /// @notice Owner can remove admin role and emit the expected events.
+    function test_removeAdmin_ownerOnly_clearsRoleAndEmits() public {
+        _addAdmin();
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, 0);
+        vm.expectEmit(false, false, false, true, address(deployer));
+        emit AdminRemoved(admin);
+
+        vm.prank(owner);
+        deployer.removeAdmin(admin);
+
+        assertEq(deployer.rolesOf(admin), 0);
+    }
+
+    /// @notice Admin can grant deployer role and emit the expected events.
+    function test_addDeployer_adminCanGrantDeployerRole() public {
+        _addAdmin();
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(authorizedDeployer, ROLE_DEPLOYER);
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit DeployerAdded(admin, authorizedDeployer);
+
+        vm.prank(admin);
+        deployer.addDeployer(authorizedDeployer);
+
+        assertEq(deployer.rolesOf(authorizedDeployer), ROLE_DEPLOYER);
+        assertTrue(deployer.hasAnyRole(authorizedDeployer, ROLE_DEPLOYER));
+    }
+
+    /// @notice Owner can grant deployer role.
+    function test_addDeployer_ownerCanGrantDeployerRole() public {
+        vm.prank(owner);
+        deployer.addDeployer(authorizedDeployer);
+
+        assertEq(deployer.rolesOf(authorizedDeployer), ROLE_DEPLOYER);
+    }
+
+    /// @notice Unauthorized callers cannot grant deployer role.
+    function test_addDeployer_revertUnauthorized() public {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.addDeployer(authorizedDeployer);
+    }
+
+    /// @notice Zero address cannot receive deployer role.
+    function test_addDeployer_revertZeroAddress() public {
+        vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
+
+        vm.prank(owner);
+        deployer.addDeployer(address(0));
+    }
+
+    /// @notice Caller cannot grant deployer role to itself.
+    function test_addDeployer_revertCallerAddress() public {
+        vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
+
+        vm.prank(owner);
+        deployer.addDeployer(owner);
+    }
+
+    /// @notice Addresses with any existing role cannot receive deployer role.
+    function test_addDeployer_revertRoleAlreadyAssigned() public {
+        _addAdmin();
+
+        vm.expectRevert(DopplerDeployer.RoleAlreadyAssigned.selector);
+
+        vm.prank(owner);
+        deployer.addDeployer(admin);
+    }
+
+    /// @notice Admin can revoke deployer role and emit the expected events.
+    function test_removeDeployer_adminCanRevokeDeployerRole() public {
+        _addAuthorizedDeployer();
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(authorizedDeployer, 0);
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit DeployerRemoved(admin, authorizedDeployer);
+
+        vm.prank(admin);
+        deployer.removeDeployer(authorizedDeployer);
+
+        assertEq(deployer.rolesOf(authorizedDeployer), 0);
+    }
+
+    /// @notice Deployer removal rejects targets without only deployer role.
+    function test_removeDeployer_revertIfTargetIsNotDeployer() public {
+        _addAdmin();
+
+        vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
+
+        vm.prank(owner);
+        deployer.removeDeployer(admin);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       SALT FUNCTIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Generated salts are deployer-keyed with name and version entropy.
+    function test_generateSalt_usesDeployerAddressAndNameVersionEntropy() public view {
+        bytes32 salt = deployer.generateSalt("DopplerDeployer", 2);
+        bytes32 expected = bytes32(uint256(uint160(address(deployer))) << 96)
+            | bytes32(uint256(keccak256(abi.encode("DopplerDeployer", uint256(2)))) >> 168);
+
+        assertEq(salt, expected);
+        assertEq(address(bytes20(salt)), address(deployer));
+        assertEq(bytes1(salt[20]), hex"00");
+    }
+
+    /// @notice Guarded salt derivation for deployer-keyed salts without redeploy protection.
+    function test_computeGuardedSalt_permissionedNoRedeployProtection() public view {
+        bytes32 salt = deployer.generateSalt("Contract", 1);
+        bytes32 expected = _efficientHash(bytes32(uint256(uint160(address(deployer)))), salt);
+
+        assertEq(deployer.computeGuardedSalt(salt), expected);
+    }
+
+    /// @notice Guarded salt derivation for deployer-keyed salts with redeploy protection.
+    function test_computeGuardedSalt_deployerWithRedeployProtection() public view {
+        bytes32 salt = _salt(address(deployer), 1, 0x1234);
+        bytes32 expected = keccak256(abi.encode(address(deployer), block.chainid, salt));
+
+        assertEq(deployer.computeGuardedSalt(salt), expected);
+    }
+
+    /// @notice Guarded salt derivation for zero-address salts without redeploy protection.
+    function test_computeGuardedSalt_zeroAddressNoRedeployProtection() public view {
+        bytes32 salt = _salt(address(0), 0, 0xbeef);
+        bytes32 expected = keccak256(abi.encode(salt));
+
+        assertEq(deployer.computeGuardedSalt(salt), expected);
+    }
+
+    /// @notice Guarded salt derivation for zero-address salts with redeploy protection.
+    function test_computeGuardedSalt_zeroAddressWithRedeployProtection() public view {
+        bytes32 salt = _salt(address(0), 1, 0xbeef);
+        bytes32 expected = _efficientHash(bytes32(block.chainid), salt);
+
+        assertEq(deployer.computeGuardedSalt(salt), expected);
+    }
+
+    /// @notice Guarded salt derivation for permissionless random sender-byte salts.
+    function test_computeGuardedSalt_randomSenderBytes() public view {
+        bytes32 salt = _salt(address(0x1234), 0, 0xbeef);
+        bytes32 expected = keccak256(abi.encode(salt));
+
+        assertEq(deployer.computeGuardedSalt(salt), expected);
+    }
+
+    /// @notice Create2 address computation matches CreateX guarded-salt computation.
+    function test_computeCreate2Address_matchesCreateXGuardedSalt() public view {
+        bytes memory initCode = _deployableInitCode(42);
+        bytes32 salt = deployer.generateSalt("Create2", 1);
+        bytes32 guardedSalt = deployer.computeGuardedSalt(salt);
+        address expected = ICreateX(CREATEX).computeCreate2Address(guardedSalt, keccak256(initCode));
+
+        assertEq(deployer.computeCreate2Address(salt, keccak256(initCode)), expected);
+    }
+
+    /// @notice Create3 address computation matches CreateX guarded-salt computation.
+    function test_computeCreate3Address_matchesCreateXGuardedSalt() public view {
+        bytes32 salt = deployer.generateSalt("Create3", 1);
+        bytes32 guardedSalt = deployer.computeGuardedSalt(salt);
+        address expected = ICreateX(CREATEX).computeCreate3Address(guardedSalt);
+
+        assertEq(deployer.computeCreate3Address(salt), expected);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CREATE2 DEPLOYMENT                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Owner can deploy with Create2 to the computed address.
+    function test_deployCreate2_ownerDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(42);
+        bytes32 salt = deployer.generateSalt("Create2Owner", 1);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit Deployed(owner, expected);
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate2(salt, initCode);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 42);
+        assertEq(DeployableContract(deployed).constructorSender(), CREATEX);
+    }
+
+    /// @notice Deployer role can deploy with default salt and expected-address check.
+    function test_deployCreate2_deployerRoleDeploysDefaultSaltToExpectedAddress() public {
+        _addAuthorizedDeployer();
+
+        bytes memory initCode = _deployableInitCode(43);
+        bytes32 salt = deployer.generateSalt("Create2Expected", 1);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.prank(authorizedDeployer);
+        address deployed = deployer.deployCreate2(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 43);
+    }
+
+    /// @notice Create2 deployment for deployer-keyed salts with redeploy protection.
+    function test_deployCreate2_deployerRedeployProtectionSaltDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(48);
+        bytes32 salt = _salt(address(deployer), 1, 0x1234);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate2(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 48);
+    }
+
+    /// @notice Create2 deployment for zero-address salts without redeploy protection.
+    function test_deployCreate2_zeroAddressSaltDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(49);
+        bytes32 salt = _salt(address(0), 0, 0x1234);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate2(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 49);
+    }
+
+    /// @notice Create2 deployment for zero-address salts with redeploy protection.
+    function test_deployCreate2_zeroAddressRedeployProtectionSaltDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(50);
+        bytes32 salt = _salt(address(0), 1, 0x1234);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate2(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 50);
+    }
+
+    /// @notice Create2 expected-address mismatch reverts and rolls back deployment.
+    function test_deployCreate2_revertExpectedAddressMismatch() public {
+        bytes memory initCode = _deployableInitCode(44);
+        bytes32 salt = deployer.generateSalt("Create2Mismatch", 1);
+        address actual = deployer.computeCreate2Address(salt, keccak256(initCode));
+        address wrongExpected = makeAddr("wrongExpected");
+
+        vm.expectRevert(abi.encodeWithSelector(DopplerDeployer.AddressMismatch.selector, actual, wrongExpected));
+
+        vm.prank(owner);
+        deployer.deployCreate2(salt, initCode, wrongExpected);
+
+        assertEq(actual.code.length, 0);
+    }
+
+    /// @notice Unauthorized callers cannot deploy with Create2.
+    function test_deployCreate2_revertUnauthorized() public {
+        bytes32 salt = deployer.generateSalt("Unauthorized", 1);
+        bytes memory initCode = _deployableInitCode(1);
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.deployCreate2(salt, initCode);
+    }
+
+    /// @notice Invalid Create2 salts revert from CreateX.
+    function test_deployCreate2_revertInvalidSaltFromCreateX() public {
+        bytes32 salt = _salt(address(deployer), 2, 0x1234);
+
+        vm.expectRevert(abi.encodeWithSelector(ICreateX.InvalidSalt.selector, CREATEX));
+
+        vm.prank(owner);
+        deployer.deployCreate2(salt, _deployableInitCode(1));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CREATE3 DEPLOYMENT                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Owner can deploy with Create3 to the computed address.
+    function test_deployCreate3_ownerDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(45);
+        bytes32 salt = deployer.generateSalt("Create3Owner", 1);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit Deployed(owner, expected);
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate3(salt, initCode);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 45);
+    }
+
+    /// @notice Deployer role can deploy with Create3 and expected-address check.
+    function test_deployCreate3_deployerRoleDeploysToExpectedAddress() public {
+        _addAuthorizedDeployer();
+
+        bytes memory initCode = _deployableInitCode(46);
+        bytes32 salt = deployer.generateSalt("Create3Expected", 1);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.prank(authorizedDeployer);
+        address deployed = deployer.deployCreate3(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 46);
+    }
+
+    /// @notice Create3 deployment for deployer-keyed salts with redeploy protection.
+    function test_deployCreate3_deployerRedeployProtectionSaltDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(51);
+        bytes32 salt = _salt(address(deployer), 1, 0x1234);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate3(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 51);
+    }
+
+    /// @notice Create3 deployment for zero-address salts without redeploy protection.
+    function test_deployCreate3_zeroAddressSaltDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(52);
+        bytes32 salt = _salt(address(0), 0, 0x1234);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate3(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 52);
+    }
+
+    /// @notice Create3 deployment for zero-address salts with redeploy protection.
+    function test_deployCreate3_zeroAddressRedeployProtectionSaltDeploysToComputedAddress() public {
+        bytes memory initCode = _deployableInitCode(53);
+        bytes32 salt = _salt(address(0), 1, 0x1234);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.prank(owner);
+        address deployed = deployer.deployCreate3(salt, initCode, expected);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 53);
+    }
+
+    /// @notice Create3 expected-address mismatch reverts and rolls back deployment.
+    function test_deployCreate3_revertExpectedAddressMismatch() public {
+        bytes memory initCode = _deployableInitCode(47);
+        bytes32 salt = deployer.generateSalt("Create3Mismatch", 1);
+        address actual = deployer.computeCreate3Address(salt);
+        address wrongExpected = makeAddr("wrongExpected");
+
+        vm.expectRevert(abi.encodeWithSelector(DopplerDeployer.AddressMismatch.selector, actual, wrongExpected));
+
+        vm.prank(owner);
+        deployer.deployCreate3(salt, initCode, wrongExpected);
+
+        assertEq(actual.code.length, 0);
+    }
+
+    /// @notice Invalid Create3 salts revert from CreateX.
+    function test_deployCreate3_revertInvalidSaltFromCreateX() public {
+        vm.expectRevert(abi.encodeWithSelector(ICreateX.InvalidSalt.selector, CREATEX));
+
+        vm.prank(owner);
+        deployer.deployCreate3(_salt(address(deployer), 2, 0x1234), _deployableInitCode(1));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          EXECUTION                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @notice Authorized single-call execution forwards value and return data.
+    function test_execute_singleCallForwardsValueAndReturnsData() public {
+        CallTarget target = new CallTarget();
+        vm.deal(authorizedDeployer, 1 ether);
+        _addAuthorizedDeployer();
+
+        vm.prank(authorizedDeployer);
+        bytes memory result =
+            deployer.execute{ value: 0.25 ether }(address(target), abi.encodeCall(CallTarget.store, (11)));
+
+        assertEq(abi.decode(result, (uint256)), 12);
+        assertEq(target.value(), 11);
+        assertEq(target.received(), 0.25 ether);
+    }
+
+    /// @notice Unauthorized callers cannot execute a single call.
+    function test_execute_singleCallRevertUnauthorized() public {
+        CallTarget target = new CallTarget();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.execute(address(target), abi.encodeCall(CallTarget.store, (1)));
+    }
+
+    /// @notice Failed single-call execution reverts with ExecutionFailed.
+    function test_execute_singleCallRevertExecutionFailed() public {
+        CallTarget target = new CallTarget();
+
+        vm.expectRevert(DopplerDeployer.ExecutionFailed.selector);
+
+        vm.prank(owner);
+        deployer.execute(address(target), abi.encodeCall(CallTarget.fail, ()));
+    }
+
+    /// @notice Authorized batch execution forwards values and return data.
+    function test_execute_batchCallsForwardValuesAndReturnData() public {
+        CallTarget first = new CallTarget();
+        CallTarget second = new CallTarget();
+        vm.deal(owner, 3 wei);
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(first);
+        targets[1] = address(second);
+
+        uint256[] memory values = new uint256[](2);
+        values[0] = 1 wei;
+        values[1] = 2 wei;
+
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeCall(CallTarget.store, (20));
+        data[1] = abi.encodeCall(CallTarget.store, (30));
+
+        vm.prank(owner);
+        bytes[] memory results = deployer.execute{ value: 3 wei }(targets, values, data);
+
+        assertEq(abi.decode(results[0], (uint256)), 21);
+        assertEq(abi.decode(results[1], (uint256)), 31);
+        assertEq(first.value(), 20);
+        assertEq(first.received(), 1 wei);
+        assertEq(second.value(), 30);
+        assertEq(second.received(), 2 wei);
+    }
+
+    /// @notice Batch execution rejects mismatched input array lengths.
+    function test_execute_batchRevertArrayLengthMismatch() public {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory data = new bytes[](1);
+
+        vm.expectRevert(DopplerDeployer.ArrayLengthsMismatch.selector);
+
+        vm.prank(owner);
+        deployer.execute(targets, values, data);
+    }
+
+    /// @notice Batch payment mismatch reverts and rolls back prior calls.
+    function test_execute_batchRevertPaymentMismatchAndRollsBackCalls() public {
+        CallTarget first = new CallTarget();
+        CallTarget second = new CallTarget();
+        vm.deal(owner, 3 wei);
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(first);
+        targets[1] = address(second);
+
+        uint256[] memory values = new uint256[](2);
+        values[0] = 1 wei;
+        values[1] = 1 wei;
+
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeCall(CallTarget.store, (20));
+        data[1] = abi.encodeCall(CallTarget.store, (30));
+
+        vm.expectRevert(abi.encodeWithSelector(DopplerDeployer.PaymentMismatch.selector, 3, 2));
+
+        vm.prank(owner);
+        deployer.execute{ value: 3 wei }(targets, values, data);
+
+        assertEq(first.value(), 0);
+        assertEq(second.value(), 0);
+    }
+
+    /// @notice Failed batch execution reverts with ExecutionFailed.
+    function test_execute_batchRevertExecutionFailed() public {
+        CallTarget target = new CallTarget();
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(target);
+
+        uint256[] memory values = new uint256[](1);
+
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeCall(CallTarget.fail, ());
+
+        vm.expectRevert(DopplerDeployer.ExecutionFailed.selector);
+
+        vm.prank(owner);
+        deployer.execute(targets, values, data);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         TEST HELPERS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function _addAdmin() internal {
+        vm.prank(owner);
+        deployer.addAdmin(admin);
+    }
+
+    function _addAuthorizedDeployer() internal {
+        _addAdmin();
+
+        vm.prank(admin);
+        deployer.addDeployer(authorizedDeployer);
+    }
+
+    function _deployableInitCode(uint256 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(type(DeployableContract).creationCode, abi.encode(value));
+    }
+
+    function _etchCreateX() internal {
+        string memory artifact = vm.readFile("lib/createx/artifacts/src/CreateX.sol/CreateX.json");
+        bytes memory creationCode = vm.parseJsonBytes(artifact, ".bytecode");
+
+        vm.etch(CREATEX, creationCode);
+        (bool success, bytes memory runtimeBytecode) = CREATEX.call("");
+        require(success, "CreateX init failed");
+        vm.etch(CREATEX, runtimeBytecode);
+        assertGt(CREATEX.code.length, 0);
+    }
+
+    function _salt(address senderBytes, uint8 redeployProtectionFlag, uint88 entropy) internal pure returns (bytes32) {
+        return
+            bytes32((uint256(uint160(senderBytes)) << 96) | (uint256(redeployProtectionFlag) << 88) | uint256(entropy));
+    }
+
+    function _efficientHash(bytes32 a, bytes32 b) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            hash := keccak256(0x00, 0x40)
+        }
+    }
+}
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                         TEST CONTRACTS                       */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+contract DeployableContract {
+    uint256 public immutable value;
+    address public immutable constructorSender;
+
+    constructor(uint256 value_) payable {
+        value = value_;
+        constructorSender = msg.sender;
+    }
+}
+
+contract CallTarget {
+    error TargetFailed();
+
+    uint256 public value;
+    uint256 public received;
+
+    function store(uint256 value_) external payable returns (uint256) {
+        value = value_;
+        received += msg.value;
+        return value_ + 1;
+    }
+
+    function fail() external pure {
+        revert TargetFailed();
+    }
+}

--- a/test/unit/DopplerDeployer.t.sol
+++ b/test/unit/DopplerDeployer.t.sol
@@ -20,7 +20,9 @@ contract DopplerDeployerTest is Test {
 
     address internal owner = makeAddr("owner");
     address internal admin = makeAddr("admin");
+    address internal secondAdmin = makeAddr("secondAdmin");
     address internal authorizedDeployer = makeAddr("authorizedDeployer");
+    address internal secondAuthorizedDeployer = makeAddr("secondAuthorizedDeployer");
     address internal stranger = makeAddr("stranger");
 
     DopplerDeployer internal deployer;
@@ -47,124 +49,168 @@ contract DopplerDeployerTest is Test {
     /*                      ROLE MANAGEMENT                       */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    /// @notice Only the owner can grant admin role and emit the expected events.
-    function test_addAdmin_ownerOnly_setsRoleAndEmits() public {
+    /// @notice Only the owner can grant admin roles and emit the expected events.
+    function test_addAdmins_ownerOnly_setsRolesAndEmits() public {
         vm.expectEmit(true, true, false, false, address(deployer));
         emit RolesUpdated(admin, ROLE_ADMIN);
         vm.expectEmit(false, false, false, true, address(deployer));
         emit AdminAdded(admin);
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(secondAdmin, ROLE_ADMIN);
+        vm.expectEmit(false, false, false, true, address(deployer));
+        emit AdminAdded(secondAdmin);
 
         vm.prank(owner);
-        deployer.addAdmin(admin);
+        deployer.addAdmins(_addresses(admin, secondAdmin));
 
         assertEq(deployer.rolesOf(admin), ROLE_ADMIN);
         assertTrue(deployer.hasAnyRole(admin, ROLE_ADMIN));
+        assertEq(deployer.rolesOf(secondAdmin), ROLE_ADMIN);
+        assertTrue(deployer.hasAnyRole(secondAdmin, ROLE_ADMIN));
     }
 
-    /// @notice Non-owners cannot grant admin role.
-    function test_addAdmin_revertUnauthorized() public {
+    /// @notice Non-owners cannot grant admin roles.
+    function test_addAdmins_revertUnauthorized() public {
         vm.expectRevert(Ownable.Unauthorized.selector);
 
         vm.prank(stranger);
-        deployer.addAdmin(admin);
+        deployer.addAdmins(_addresses(admin));
     }
 
-    /// @notice Owner can remove admin role and emit the expected events.
-    function test_removeAdmin_ownerOnly_clearsRoleAndEmits() public {
-        _addAdmin();
+    /// @notice Owner can remove admin roles and emit the expected events.
+    function test_removeAdmins_ownerOnly_clearsRolesAndEmits() public {
+        _addAdmins();
 
         vm.expectEmit(true, true, false, false, address(deployer));
         emit RolesUpdated(admin, 0);
         vm.expectEmit(false, false, false, true, address(deployer));
         emit AdminRemoved(admin);
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(secondAdmin, 0);
+        vm.expectEmit(false, false, false, true, address(deployer));
+        emit AdminRemoved(secondAdmin);
 
         vm.prank(owner);
-        deployer.removeAdmin(admin);
+        deployer.removeAdmins(_addresses(admin, secondAdmin));
 
         assertEq(deployer.rolesOf(admin), 0);
+        assertEq(deployer.rolesOf(secondAdmin), 0);
     }
 
-    /// @notice Admin can grant deployer role and emit the expected events.
-    function test_addDeployer_adminCanGrantDeployerRole() public {
+    /// @notice Admin can grant deployer roles and emit the expected events.
+    function test_addDeployers_adminCanGrantDeployerRoles() public {
         _addAdmin();
 
         vm.expectEmit(true, true, false, false, address(deployer));
         emit RolesUpdated(authorizedDeployer, ROLE_DEPLOYER);
         vm.expectEmit(true, false, false, true, address(deployer));
         emit DeployerAdded(admin, authorizedDeployer);
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(secondAuthorizedDeployer, ROLE_DEPLOYER);
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit DeployerAdded(admin, secondAuthorizedDeployer);
 
         vm.prank(admin);
-        deployer.addDeployer(authorizedDeployer);
+        deployer.addDeployers(_addresses(authorizedDeployer, secondAuthorizedDeployer));
 
         assertEq(deployer.rolesOf(authorizedDeployer), ROLE_DEPLOYER);
         assertTrue(deployer.hasAnyRole(authorizedDeployer, ROLE_DEPLOYER));
+        assertEq(deployer.rolesOf(secondAuthorizedDeployer), ROLE_DEPLOYER);
+        assertTrue(deployer.hasAnyRole(secondAuthorizedDeployer, ROLE_DEPLOYER));
     }
 
-    /// @notice Owner can grant deployer role.
-    function test_addDeployer_ownerCanGrantDeployerRole() public {
+    /// @notice Owner can grant deployer roles.
+    function test_addDeployers_ownerCanGrantDeployerRoles() public {
         vm.prank(owner);
-        deployer.addDeployer(authorizedDeployer);
+        deployer.addDeployers(_addresses(authorizedDeployer, secondAuthorizedDeployer));
 
         assertEq(deployer.rolesOf(authorizedDeployer), ROLE_DEPLOYER);
+        assertEq(deployer.rolesOf(secondAuthorizedDeployer), ROLE_DEPLOYER);
     }
 
-    /// @notice Unauthorized callers cannot grant deployer role.
-    function test_addDeployer_revertUnauthorized() public {
+    /// @notice Unauthorized callers cannot grant deployer roles.
+    function test_addDeployers_revertUnauthorized() public {
         vm.expectRevert(Ownable.Unauthorized.selector);
 
         vm.prank(stranger);
-        deployer.addDeployer(authorizedDeployer);
+        deployer.addDeployers(_addresses(authorizedDeployer));
     }
 
-    /// @notice Zero address cannot receive deployer role.
-    function test_addDeployer_revertZeroAddress() public {
+    /// @notice Zero address cannot receive deployer roles.
+    function test_addDeployers_revertZeroAddress() public {
         vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
 
         vm.prank(owner);
-        deployer.addDeployer(address(0));
+        deployer.addDeployers(_addresses(address(0)));
     }
 
-    /// @notice Caller cannot grant deployer role to itself.
-    function test_addDeployer_revertCallerAddress() public {
+    /// @notice Caller cannot grant deployer roles to itself.
+    function test_addDeployers_revertCallerAddress() public {
         vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
 
         vm.prank(owner);
-        deployer.addDeployer(owner);
+        deployer.addDeployers(_addresses(owner));
     }
 
-    /// @notice Addresses with any existing role cannot receive deployer role.
-    function test_addDeployer_revertRoleAlreadyAssigned() public {
+    /// @notice Addresses with any existing role cannot receive deployer roles.
+    function test_addDeployers_revertRoleAlreadyAssigned() public {
         _addAdmin();
 
         vm.expectRevert(DopplerDeployer.RoleAlreadyAssigned.selector);
 
         vm.prank(owner);
-        deployer.addDeployer(admin);
+        deployer.addDeployers(_addresses(admin));
     }
 
-    /// @notice Admin can revoke deployer role and emit the expected events.
-    function test_removeDeployer_adminCanRevokeDeployerRole() public {
-        _addAuthorizedDeployer();
+    /// @notice Admin can revoke deployer roles and emit the expected events.
+    function test_removeDeployers_adminCanRevokeDeployerRoles() public {
+        _addAuthorizedDeployers();
 
         vm.expectEmit(true, true, false, false, address(deployer));
         emit RolesUpdated(authorizedDeployer, 0);
         vm.expectEmit(true, false, false, true, address(deployer));
         emit DeployerRemoved(admin, authorizedDeployer);
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(secondAuthorizedDeployer, 0);
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit DeployerRemoved(admin, secondAuthorizedDeployer);
 
         vm.prank(admin);
-        deployer.removeDeployer(authorizedDeployer);
+        deployer.removeDeployers(_addresses(authorizedDeployer, secondAuthorizedDeployer));
 
         assertEq(deployer.rolesOf(authorizedDeployer), 0);
+        assertEq(deployer.rolesOf(secondAuthorizedDeployer), 0);
+    }
+
+    /// @notice Owner can revoke deployer roles.
+    function test_removeDeployers_ownerCanRevokeDeployerRoles() public {
+        _addAuthorizedDeployers();
+
+        vm.prank(owner);
+        deployer.removeDeployers(_addresses(authorizedDeployer, secondAuthorizedDeployer));
+
+        assertEq(deployer.rolesOf(authorizedDeployer), 0);
+        assertEq(deployer.rolesOf(secondAuthorizedDeployer), 0);
+    }
+
+    /// @notice Unauthorized callers cannot revoke deployer roles.
+    function test_removeDeployers_revertUnauthorized() public {
+        _addAuthorizedDeployer();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.removeDeployers(_addresses(authorizedDeployer));
     }
 
     /// @notice Deployer removal rejects targets without only deployer role.
-    function test_removeDeployer_revertIfTargetIsNotDeployer() public {
+    function test_removeDeployers_revertIfTargetIsNotDeployer() public {
         _addAdmin();
 
         vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
 
         vm.prank(owner);
-        deployer.removeDeployer(admin);
+        deployer.removeDeployers(_addresses(admin));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -580,14 +626,37 @@ contract DopplerDeployerTest is Test {
 
     function _addAdmin() internal {
         vm.prank(owner);
-        deployer.addAdmin(admin);
+        deployer.addAdmins(_addresses(admin));
+    }
+
+    function _addAdmins() internal {
+        vm.prank(owner);
+        deployer.addAdmins(_addresses(admin, secondAdmin));
     }
 
     function _addAuthorizedDeployer() internal {
         _addAdmin();
 
         vm.prank(admin);
-        deployer.addDeployer(authorizedDeployer);
+        deployer.addDeployers(_addresses(authorizedDeployer));
+    }
+
+    function _addAuthorizedDeployers() internal {
+        _addAdmin();
+
+        vm.prank(admin);
+        deployer.addDeployers(_addresses(authorizedDeployer, secondAuthorizedDeployer));
+    }
+
+    function _addresses(address first) internal pure returns (address[] memory addresses) {
+        addresses = new address[](1);
+        addresses[0] = first;
+    }
+
+    function _addresses(address first, address second) internal pure returns (address[] memory addresses) {
+        addresses = new address[](2);
+        addresses[0] = first;
+        addresses[1] = second;
     }
 
     function _deployableInitCode(uint256 value) internal pure returns (bytes memory) {


### PR DESCRIPTION
## Description

Adds a new `DopplerDeployer` contract for permissioned deterministic deployments through `CreateX`, plus a comprehensive unit test suite covering roles, salt/address derivation, Create2/Create3 deployments, expected-address checks, and execution helpers. A protected files github workflow was also added that alerts when certain protected files, such as this deployer, are altered.

## Motivation

These changes provide a dedicated deployment contract for future protocol deployments while preserving deterministic address computation across `CreateX` salt modes. The deployer was marked as a protected file as any changes could significantly impact our ability to sustain equivalent deterministic deployments across chains.

## Changes

- Added `src/DopplerDeployer.sol`
  - Owner/admin/deployer role management.
  - `CreateX` Create2/Create3 deployment wrappers.
  - Expected-address deployment overloads.
  - Guarded salt and address computation helpers.
  - Single-call and batch execution helpers.
- Added `test/unit/DopplerDeployer.t.sol`
  - Etches canonical `CreateX` for deterministic local tests.
  - Covers constructor and role management.
  - Covers deployer-keyed, redeploy-protected, and permissionless salt behavior.
  - Covers Create2/Create3 address computation and actual deployments.
  - Covers expected-address mismatch reverts and `CreateX` invalid-salt reverts.
  - Covers single and batch execution success and failure paths.
- Added `.github/protected-files.txt`
  - Functions as a blocklist for PRs that alter included files.
- Added `.github/workflows/protected-files.yml`
  - CI job that flags PRs that alter protected files.