### PR TITLE
feat: initial scope for deploy script overhaul

### DIFF
--- a/.github/protected-files.txt
+++ b/.github/protected-files.txt
@@ -1,2 +1,3 @@
 # One repository-relative path per line. Lines starting with # are ignored.
-src/DopplerDeployer.sol
+src/DopplerCreateXDeployer.sol
+script/DeployDopplerCreateXDeployer.s.sol

--- a/legacy/script/deploy/DeployAirlock.s.sol
+++ b/legacy/script/deploy/DeployAirlock.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt } from "script/utils/CreateX.sol";
+import { Airlock } from "src/Airlock.sol";
+
+contract DeployAirlockScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](2);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address createX = config.get("create_x").toAddress();
+        address multisig = config.get("airlock_multisig").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = bytes32((uint256(uint160(msg.sender)) << 96) + uint256(0xb16b055));
+        address predictedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address airlock =
+            ICreateX(createX).deployCreate3(salt, abi.encodePacked(type(Airlock).creationCode, abi.encode(multisig)));
+        require(airlock == predictedAddress, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        config.set("airlock", airlock);
+    }
+}

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { StdConfig } from "forge-std/StdConfig.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { Versions } from "script/utils/Versions.sol";
+import { DopplerCreateXDeployer } from "src/DopplerCreateXDeployer.sol";
+
+abstract contract DeployBase is Script, Config, Versions {
+    ICreateX internal constant CREATE_X = ICreateX(0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed);
+    string internal constant DEPLOYMENTS_CONFIG_PATH = "./deployments.config.toml";
+    string internal constant PROTOCOL_DEPLOYER_KEY = "protocol_deployer";
+
+    error Create3AddressMismatch(bytes32 salt, address expected, address computed);
+    error InvalidCreateXGuardedSalt(bytes32 salt);
+    error BroadcastSenderMismatch(address expected, address actual);
+
+    struct DeployContext {
+        uint256 chainId;
+        StdConfig config;
+        DopplerCreateXDeployer protocolDeployer;
+        address broadcaster;
+        bool writeConfig;
+    }
+
+    /// @notice Loads the shared deployments config for the chain selected by the caller.
+    /// @dev Standalone scripts use this when the fork or RPC context is supplied by forge CLI arguments.
+    function _loadConfigForCurrentChain() internal {
+        _loadConfig(DEPLOYMENTS_CONFIG_PATH, true);
+    }
+
+    /// @notice Loads the shared deployments config and selects a fork for `chainId`.
+    /// @dev Chain-specific aggregate scripts use this to run with baked-in defaults instead of CLI chain arguments.
+    function _loadConfigAndSelectFork(uint256 chainId) internal {
+        _loadConfig(DEPLOYMENTS_CONFIG_PATH, true);
+        vm.createSelectFork(config.getRpcUrl(chainId));
+        require(block.chainid == chainId, "Selected fork has unexpected chainId");
+    }
+
+    /// @notice Builds the common deployment context for scripts that deploy through the protocol deployer.
+    /// @dev Resolves chain config, the protocol deployer address, broadcaster, and whether config writes are enabled.
+    function _deployContext() internal view returns (DeployContext memory context) {
+        uint256 chainId = block.chainid;
+        require(config.exists(chainId, PROTOCOL_DEPLOYER_KEY), "protocol_deployer is not configured");
+
+        context = DeployContext({
+            chainId: chainId,
+            config: config,
+            protocolDeployer: DopplerCreateXDeployer(config.get(chainId, PROTOCOL_DEPLOYER_KEY).toAddress()),
+            broadcaster: msg.sender,
+            writeConfig: _shouldWriteConfig()
+        });
+    }
+
+    /// @notice Returns whether the current script execution should persist deployment addresses to config.
+    /// @dev Config writes are limited to broadcast runs so simulations and dry runs do not mutate local config.
+    function _shouldWriteConfig() internal view returns (bool) {
+        return vm.isContext(VmSafe.ForgeContext.ScriptBroadcast);
+    }
+
+    /// @notice Writes a chain-scoped address into the shared deployments config when writes are enabled.
+    /// @dev Scripts using `DeployContext` use this to persist protocol contract addresses after deploy or reuse.
+    function _setConfigAddress(DeployContext memory context, string memory key, address value) internal {
+        if (context.writeConfig) {
+            context.config.set(context.chainId, key, value);
+        }
+    }
+
+    /// @notice Writes an address into the active config section when writes are enabled.
+    /// @dev Bootstrap scripts use this before a `DeployContext` exists, such as when deploying the protocol deployer.
+    function _setConfigAddress(string memory key, address value) internal {
+        if (_shouldWriteConfig()) {
+            config.set(key, value);
+        }
+    }
+
+    /// @notice Deploys a contract through the protocol deployer or returns an existing deployment at `expected`.
+    /// @dev Verifies the salt computes to `expected` before checking code or broadcasting to avoid trusting
+    ///      unrelated occupied addresses. Callers are responsible for validating and recording the deployment.
+    function _deployOrUseExistingCreate3(
+        DeployContext memory context,
+        bytes32 deploymentSalt,
+        address expected,
+        bytes memory initCode
+    ) internal returns (address deployed, bool alreadyDeployed) {
+        address computed = _computeProtocolCreate3Address(context.protocolDeployer, deploymentSalt);
+        _verifyCreate3Address(deploymentSalt, expected, computed);
+
+        if (expected.code.length != 0) {
+            return (expected, true);
+        }
+
+        vm.startBroadcast();
+        deployed = context.protocolDeployer.deployCreate3(deploymentSalt, initCode, expected);
+        vm.stopBroadcast();
+
+        _verifyCreate3Address(deploymentSalt, expected, deployed);
+        return (deployed, false);
+    }
+
+    /// @notice Deploys a bootstrap contract directly through CreateX or returns existing code at `expected`.
+    /// @dev Used for contracts needed before the protocol deployer exists and mirrors CreateX guarded salt handling.
+    ///      Callers are responsible for validating and recording the deployment.
+    function _deployOrUseExistingCreateXCreate3(
+        bytes32 deploymentSalt,
+        address expected,
+        bytes memory initCode
+    ) internal returns (address deployed, bool alreadyDeployed) {
+        address broadcaster = _resolveBroadcastSender();
+        address computed = _computeCreateXCreate3Address(deploymentSalt, broadcaster);
+        _verifyCreate3Address(deploymentSalt, expected, computed);
+
+        if (expected.code.length != 0) {
+            return (expected, true);
+        }
+
+        vm.startBroadcast();
+        _verifyBroadcastSender(broadcaster);
+        deployed = CREATE_X.deployCreate3(deploymentSalt, initCode);
+        vm.stopBroadcast();
+
+        _verifyCreate3Address(deploymentSalt, expected, deployed);
+        return (deployed, false);
+    }
+
+    /// @notice Reverts unless a computed or deployed CREATE3 address matches the expected address.
+    /// @dev Centralizes the assurance that an overridden salt and expected address pair are internally consistent.
+    function _verifyCreate3Address(bytes32 deploymentSalt, address expected, address computed) internal pure {
+        if (computed != expected) {
+            revert Create3AddressMismatch(deploymentSalt, expected, computed);
+        }
+    }
+
+    /// @notice Computes the CREATE3 address for a deployment sent through the protocol deployer.
+    /// @dev Uses the protocol deployer's `computeGuardedSalt` wrapper because CreateX computes addresses from guarded salts.
+    function _computeProtocolCreate3Address(
+        DopplerCreateXDeployer protocolDeployer,
+        bytes32 deploymentSalt
+    ) internal view returns (address) {
+        bytes32 guardedSalt = protocolDeployer.computeGuardedSalt(deploymentSalt);
+        return CREATE_X.computeCreate3Address(guardedSalt);
+    }
+
+    /// @notice Computes the direct CreateX CREATE3 address for `deploymentSalt` and `caller`.
+    /// @dev Used by bootstrap scripts that call CreateX directly instead of routing through the protocol deployer.
+    function _computeCreateXCreate3Address(bytes32 deploymentSalt, address caller) internal view returns (address) {
+        return CREATE_X.computeCreate3Address(_computeCreateXGuardedSalt(deploymentSalt, caller));
+    }
+
+    /// @notice Resolves the sender Foundry will use for default `vm.startBroadcast()` calls.
+    /// @dev Starts and stops a broadcast section without external calls, so no transaction is recorded.
+    function _resolveBroadcastSender() internal returns (address broadcaster) {
+        vm.startBroadcast();
+        (, broadcaster,) = vm.readCallers();
+        vm.stopBroadcast();
+    }
+
+    /// @notice Reverts if the active broadcast sender differs from the sender used for address precomputation.
+    function _verifyBroadcastSender(address expected) internal view {
+        (VmSafe.CallerMode callerMode, address actual,) = vm.readCallers();
+        if (callerMode != VmSafe.CallerMode.RecurrentBroadcast || actual != expected) {
+            revert BroadcastSenderMismatch(expected, actual);
+        }
+    }
+
+    /// @notice Computes the guarded salt that CreateX will derive from `deploymentSalt` for `caller`.
+    /// @dev Mirrors CreateX salt-guard logic so scripts can preflight expected addresses before broadcasting.
+    function _computeCreateXGuardedSalt(bytes32 deploymentSalt, address caller) internal view returns (bytes32) {
+        address senderBytes = address(bytes20(deploymentSalt));
+        bytes1 redeployProtectionFlag = deploymentSalt[20];
+
+        if (senderBytes == caller) {
+            if (redeployProtectionFlag == hex"00") {
+                return _efficientHash({ a: bytes32(uint256(uint160(caller))), b: deploymentSalt });
+            }
+            if (redeployProtectionFlag == hex"01") {
+                return keccak256(abi.encode(caller, block.chainid, deploymentSalt));
+            }
+            revert InvalidCreateXGuardedSalt(deploymentSalt);
+        }
+
+        if (senderBytes == address(0)) {
+            if (redeployProtectionFlag == hex"01") {
+                return _efficientHash({ a: bytes32(block.chainid), b: deploymentSalt });
+            }
+            if (redeployProtectionFlag != hex"00") {
+                revert InvalidCreateXGuardedSalt(deploymentSalt);
+            }
+        }
+
+        return deploymentSalt == _generatedCreateXSalt(caller) ? deploymentSalt : keccak256(abi.encode(deploymentSalt));
+    }
+
+    /// @notice Reconstructs the generated salt value CreateX recognizes for the current block context and caller.
+    /// @dev Needed only to mirror CreateX's branch that skips hashing when the caller supplied its generated salt.
+    function _generatedCreateXSalt(address caller) internal view returns (bytes32) {
+        unchecked {
+            return keccak256(
+                abi.encode(
+                    blockhash(block.number - 32),
+                    block.coinbase,
+                    block.number,
+                    block.timestamp,
+                    block.prevrandao,
+                    block.chainid,
+                    caller
+                )
+            );
+        }
+    }
+
+    /// @notice Hashes two words using the same packed-memory pattern used by CreateX.
+    /// @dev Keeps local guarded-salt computation byte-compatible with CreateX for sender and chain guarded salts.
+    function _efficientHash(bytes32 a, bytes32 b) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            hash := keccak256(0x00, 0x40)
+        }
+    }
+}

--- a/script/DeployDoppler.s.sol
+++ b/script/DeployDoppler.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { DeployAirlock } from "script/deploy/DeployAirlock.s.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+
+contract DeployDopplerScript is DeployAirlock {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public {
+        _deployAirlock(_deployContext());
+        // TODO: Revise remaining deployment scripts to follow the patterns established in DeployDeployerScript and DeployAirlockScript
+        // Then update this script to call each of the remaining deployment scripts for all contracts specified in Versions.sol
+    }
+}
+
+contract DeployDopplerScriptEthereum is DeployDopplerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET);
+    }
+}
+
+contract DeployDopplerScriptMonad is DeployDopplerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET);
+    }
+}
+
+contract DeployDopplerScriptBase is DeployDopplerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET);
+    }
+}
+
+contract DeployDopplerScriptBaseSepolia is DeployDopplerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA);
+    }
+}

--- a/script/DeployDopplerCreateXDeployer.s.sol
+++ b/script/DeployDopplerCreateXDeployer.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
+import { DopplerCreateXDeployer } from "src/DopplerCreateXDeployer.sol";
+
+contract DeployDopplerCreateXDeployerScript is DeployBase {
+    bytes32 public salt; // TODO: Mine and set a salt
+    address public expectedAddress; // TODO: Compute expected address from salt and init code hash
+
+    function setUp() public {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public {
+        require(salt != bytes32(0), "Salt is not configured");
+        require(expectedAddress != address(0), "Expected address is not configured");
+
+        address deployerOwner = config.get("deployer_owner").toAddress();
+        bytes memory initCode = abi.encodePacked(type(DopplerCreateXDeployer).creationCode, abi.encode(deployerOwner));
+
+        (address deployer, bool alreadyDeployed) = _deployOrUseExistingCreateXCreate3(salt, expectedAddress, initCode);
+
+        _verifyExistingDeployment(deployer, deployerOwner);
+        _setConfigAddress(PROTOCOL_DEPLOYER_KEY, deployer);
+
+        if (alreadyDeployed) {
+            console.log("Protocol deployer already deployed to:", deployer);
+        } else {
+            console.log("Protocol deployer deployed to:", deployer);
+        }
+    }
+
+    function _verifyExistingDeployment(address addr, address owner) internal view {
+        DopplerCreateXDeployer deployer = DopplerCreateXDeployer(payable(addr));
+
+        // Verify owner
+        if (owner != address(0)) require(deployer.owner() == owner, "Deployer owner mismatch");
+
+        // Verify interface
+        bytes32 _salt = deployer.generateSalt("DopplerCreateXDeployer", 1);
+        bytes32 guardedSalt = deployer.computeGuardedSalt(_salt);
+        deployer.computeCreate2Address(
+            guardedSalt, keccak256(abi.encodePacked(type(DopplerCreateXDeployer).creationCode, abi.encode(owner)))
+        );
+        deployer.computeCreate3Address(guardedSalt);
+    }
+}

--- a/script/deploy/DeployAirlock.s.sol
+++ b/script/deploy/DeployAirlock.s.sol
@@ -1,42 +1,64 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt } from "script/utils/CreateX.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { Airlock } from "src/Airlock.sol";
 
-contract DeployAirlockScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployAirlock is DeployBase {
+    bytes32 public salt; // Only set if you want to use a specific salt
+    address public expectedAddress; // Only set if you've configured a custom salt
 
-        uint256[] memory targets = new uint256[](2);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
+    function _deployAirlock(DeployContext memory context) internal returns (address airlock) {
+        if (salt != bytes32(0) || expectedAddress != address(0)) {
+            require(salt != bytes32(0) && expectedAddress != address(0), "Deployment configuration is incomplete");
+        }
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        address multisig = context.config.get(context.chainId, "airlock_multisig").toAddress();
+
+        bytes32 deploymentSalt =
+            salt != bytes32(0) ? salt : context.protocolDeployer.generateSalt(type(Airlock).name, AIRLOCK_VERSION);
+        address computedExpected = _computeProtocolCreate3Address(context.protocolDeployer, deploymentSalt);
+        address deploymentExpected = expectedAddress != address(0) ? expectedAddress : computedExpected;
+        bytes memory initCode = abi.encodePacked(type(Airlock).creationCode, abi.encode(multisig));
+
+        bool alreadyDeployed;
+        (airlock, alreadyDeployed) = _deployOrUseExistingCreate3(context, deploymentSalt, deploymentExpected, initCode);
+
+        _verifyExistingDeployment(airlock, multisig);
+        _setConfigAddress(context, "airlock", airlock);
+
+        if (alreadyDeployed) {
+            console.log("Airlock already deployed to:", airlock);
+        } else {
+            console.log("Airlock deployed to:", airlock);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _verifyExistingDeployment(address addr, address owner) internal view {
+        Airlock airlock = Airlock(payable(addr));
 
-        address createX = config.get("create_x").toAddress();
-        address multisig = config.get("airlock_multisig").toAddress();
+        // Verify owner
+        if (owner != address(0)) require(airlock.owner() == owner, "Airlock owner mismatch");
 
-        vm.startBroadcast();
-        bytes32 salt = bytes32((uint256(uint160(msg.sender)) << 96) + uint256(0xb16b055));
-        address predictedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+        // Verify interface
+        airlock.getModuleState(address(0));
+        airlock.getAssetData(address(0));
+        airlock.getProtocolFees(address(0));
+        airlock.getIntegratorFees(address(0), address(0));
+    }
+}
 
-        address airlock =
-            ICreateX(createX).deployCreate3(salt, abi.encodePacked(type(Airlock).creationCode, abi.encode(multisig)));
-        require(airlock == predictedAddress, "Unexpected deployed address");
-        vm.stopBroadcast();
+contract DeployAirlockScript is DeployAirlock {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        config.set("airlock", airlock);
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address airlock) {
+        return _deployAirlock(_deployContext());
     }
 }

--- a/script/utils/Versions.sol
+++ b/script/utils/Versions.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+contract Versions {
+    // --- Core ---
+    uint8 public constant AIRLOCK_MULTISIG_VERSION = 0;
+    uint8 public constant AIRLOCK_VERSION = 0;
+    uint8 public constant BUNDLER_VERSION = 0;
+    uint8 public constant TOP_UP_DISTRIBUTOR_VERSION = 0;
+    // --- Lockers ---
+    uint8 public constant STREAMABLE_FEES_LOCKER_VERSION = 0;
+    // UniswapV2Locker is deployed by UniswapV2MigratorSplit
+    // --- Token factories ---
+    uint8 public constant DOPPLER_ERC20_V1_FACTORY_VERSION = 0;
+    uint8 public constant DOPPLER_DN404_FACTORY_VERSION = 0;
+    // --- Governance factories ---
+    uint8 public constant GOVERNANCE_FACTORY_VERSION = 0;
+    uint8 public constant LAUNCHPAD_GOVERNANCE_FACTORY_VERSION = 0;
+    uint8 public constant NO_OP_GOVERNANCE_FACTORY_VERSION = 0;
+    // --- Initializers ---
+    uint8 public constant STATIC_INITIALIZER_VERSION = 0;
+    uint8 public constant DYNAMIC_INITIALIZER_VERSION = 0;
+    uint8 public constant MULTICURVE_INITIALIZER_VERSION = 0;
+    // --- Migrators ---
+    uint8 public constant DOPPLER_HOOK_MIGRATOR_VERSION = 0;
+    uint8 public constant UNISWAP_V2_MIGRATOR_SPLIT_VERSION = 0;
+    uint8 public constant NO_OP_MIGRATOR_VERSION = 0;
+    // --- Doppler Hooks ---
+    uint8 public constant REHYPE_DOPPLER_HOOK_INITIALIZER_VERSION = 0;
+    uint8 public constant REHYPE_DOPPLER_HOOK_MIGRATOR_VERSION = 0;
+    uint8 public constant SWAP_RESTRICTOR_DOPPLER_HOOK_VERSION = 0;
+    // --- Other ---
+    uint8 public constant DOPPLER_LENS_QUOTER_VERSION = 0;
+}

--- a/src/DopplerCreateXDeployer.sol
+++ b/src/DopplerCreateXDeployer.sol
@@ -4,9 +4,13 @@ pragma solidity ^0.8.24;
 import { ICreateX } from "createx/ICreateX.sol";
 import { OwnableRoles } from "solady/auth/OwnableRoles.sol";
 
-/// @title DopplerDeployer
+/// @title DopplerCreateXDeployer
 /// @notice Permissioned wrapper around CreateX for deterministic Doppler protocol deployments.
-contract DopplerDeployer is OwnableRoles {
+contract DopplerCreateXDeployer is OwnableRoles {
+    /// @notice Admin address is invalid for the requested role update.
+    error InvalidAdmin();
+    /// @notice Address is invalid for the requested role update.
+    error InvalidAddress();
     /// @notice Batch call ETH value did not equal the supplied per-call values.
     error PaymentMismatch(uint256 actual, uint256 expected);
     /// @notice Deployed address differed from the caller-supplied expected address.
@@ -15,8 +19,6 @@ contract DopplerDeployer is OwnableRoles {
     error ExecutionFailed();
     /// @notice Deployer role target is invalid for the requested role update.
     error InvalidDeployer();
-    /// @notice A role assignment was attempted for an address that already has a role.
-    error RoleAlreadyAssigned();
     /// @notice Batch execution arrays must have identical lengths.
     error ArrayLengthsMismatch();
 
@@ -24,6 +26,8 @@ contract DopplerDeployer is OwnableRoles {
     event AdminAdded(address admin);
     /// @notice Emitted when the owner removes admin privileges.
     event AdminRemoved(address admin);
+    /// @notice Emitted when the owner revokes roles from an address.
+    event RolesRevoked(address indexed addr);
     /// @notice Emitted when an admin or owner grants deployer privileges.
     event DeployerAdded(address indexed admin, address deployer);
     /// @notice Emitted when an admin or owner removes deployer privileges.
@@ -52,6 +56,7 @@ contract DopplerDeployer is OwnableRoles {
     function addAdmins(address[] calldata admins) external onlyOwner {
         for (uint256 i; i < admins.length; ++i) {
             address admin = admins[i];
+            require(admin != address(0) && admin != msg.sender, InvalidAdmin());
             _setRoles(admin, _ROLE_ADMIN);
             emit AdminAdded(admin);
         }
@@ -61,29 +66,41 @@ contract DopplerDeployer is OwnableRoles {
     function removeAdmins(address[] calldata admins) external onlyOwner {
         for (uint256 i; i < admins.length; ++i) {
             address admin = admins[i];
+            require(admin != address(0) && admin != msg.sender, InvalidAdmin());
+            require(hasAnyRole(admin, _ROLE_ADMIN), InvalidAdmin());
             _setRoles(admin, 0);
             emit AdminRemoved(admin);
         }
     }
 
+    /// @notice Revokes all roles from each address, regardless of prior role.
+    function revokeRoles(address[] calldata addrs) external onlyOwner {
+        for (uint256 i; i < addrs.length; ++i) {
+            address addr = addrs[i];
+            require(addr != address(0) && addr != msg.sender, InvalidAddress());
+            require(rolesOf(addr) != 0, InvalidAddress());
+            _setRoles(addr, 0);
+            emit RolesRevoked(addr);
+        }
+    }
+
     /// @notice Grants deployer privileges to each address.
-    /// @dev Each target must not already have a role and cannot be the caller.
     function addDeployers(address[] calldata deployers) external onlyRolesOrOwner(_ROLE_ADMIN) {
         for (uint256 i; i < deployers.length; ++i) {
             address deployer = deployers[i];
-            require(rolesOf(deployer) == 0, RoleAlreadyAssigned());
             require(deployer != address(0) && deployer != msg.sender, InvalidDeployer());
-            _grantRoles(deployer, _ROLE_DEPLOYER);
+            _setRoles(deployer, _ROLE_DEPLOYER);
             emit DeployerAdded(msg.sender, deployer);
         }
     }
 
-    /// @notice Removes deployer privileges from each address.
+    /// @notice Removes all roles from each deployer address.
     function removeDeployers(address[] calldata deployers) external onlyRolesOrOwner(_ROLE_ADMIN) {
         for (uint256 i; i < deployers.length; ++i) {
             address deployer = deployers[i];
-            require(rolesOf(deployer) == _ROLE_DEPLOYER, InvalidDeployer());
-            _removeRoles(deployer, _ROLE_DEPLOYER);
+            require(deployer != address(0) && deployer != msg.sender, InvalidDeployer());
+            require(hasAnyRole(deployer, _ROLE_DEPLOYER), InvalidDeployer());
+            _setRoles(deployer, 0);
             emit DeployerRemoved(msg.sender, deployer);
         }
     }
@@ -99,18 +116,32 @@ contract DopplerDeployer is OwnableRoles {
     }
 
     /// @notice Computes the guarded salt CreateX will use for an explicit salt deployment.
-    function computeGuardedSalt(bytes32 salt) external view returns (bytes32) {
-        return _guardSalt(salt);
+    function computeGuardedSalt(bytes32 salt) public view returns (bytes32) {
+        address senderBytes = address(bytes20(salt));
+        bytes1 redeployProtectionFlag = salt[20];
+
+        if (senderBytes == address(this)) {
+            if (redeployProtectionFlag == hex"00") {
+                return _efficientHash({ a: bytes32(uint256(uint160(address(this)))), b: salt });
+            }
+            if (redeployProtectionFlag == hex"01") {
+                return keccak256(abi.encode(address(this), block.chainid, salt));
+            }
+        } else if (senderBytes == address(0) && redeployProtectionFlag == hex"01") {
+            return _efficientHash({ a: bytes32(block.chainid), b: salt });
+        }
+
+        return keccak256(abi.encode(salt));
     }
 
     /// @notice Computes the Create2 address for a salt and init code hash using CreateX guard rules.
     function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address) {
-        return CreateX.computeCreate2Address(_guardSalt(salt), initCodeHash);
+        return CreateX.computeCreate2Address(computeGuardedSalt(salt), initCodeHash);
     }
 
     /// @notice Computes the Create3 address for a salt using CreateX guard rules.
     function computeCreate3Address(bytes32 salt) external view returns (address) {
-        return CreateX.computeCreate3Address(_guardSalt(salt));
+        return CreateX.computeCreate3Address(computeGuardedSalt(salt));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -157,8 +188,8 @@ contract DopplerDeployer is OwnableRoles {
     function deployCreate2(
         bytes32 salt,
         bytes calldata initCode
-    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
-        address deployed = CreateX.deployCreate2(salt, initCode);
+    ) external payable onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate2{ value: msg.value }(salt, initCode);
         emit Deployed(msg.sender, deployed);
         return deployed;
     }
@@ -169,8 +200,8 @@ contract DopplerDeployer is OwnableRoles {
         bytes32 salt,
         bytes calldata initCode,
         address expected
-    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
-        address deployed = CreateX.deployCreate2(salt, initCode);
+    ) external payable onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate2{ value: msg.value }(salt, initCode);
         require(deployed == expected, AddressMismatch(deployed, expected));
         emit Deployed(msg.sender, deployed);
         return deployed;
@@ -181,8 +212,8 @@ contract DopplerDeployer is OwnableRoles {
     function deployCreate3(
         bytes32 salt,
         bytes calldata initCode
-    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
-        address deployed = CreateX.deployCreate3(salt, initCode);
+    ) external payable onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate3{ value: msg.value }(salt, initCode);
         emit Deployed(msg.sender, deployed);
         return deployed;
     }
@@ -193,8 +224,8 @@ contract DopplerDeployer is OwnableRoles {
         bytes32 salt,
         bytes calldata initCode,
         address expected
-    ) external onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
-        address deployed = CreateX.deployCreate3(salt, initCode);
+    ) external payable onlyRolesOrOwner(_ROLE_AUTHORIZED) returns (address) {
+        address deployed = CreateX.deployCreate3{ value: msg.value }(salt, initCode);
         require(deployed == expected, AddressMismatch(deployed, expected));
         emit Deployed(msg.sender, deployed);
         return deployed;
@@ -211,24 +242,5 @@ contract DopplerDeployer is OwnableRoles {
             mstore(0x20, b)
             hash := keccak256(0x00, 0x40)
         }
-    }
-
-    /// @dev Mirrors CreateX guarded salts for explicit salt calls, salt validation happens in CreateX.
-    function _guardSalt(bytes32 salt) internal view returns (bytes32) {
-        address senderBytes = address(bytes20(salt));
-        bytes1 redeployProtectionFlag = salt[20];
-
-        if (senderBytes == address(this)) {
-            if (redeployProtectionFlag == hex"00") {
-                return _efficientHash({ a: bytes32(uint256(uint160(address(this)))), b: salt });
-            }
-            if (redeployProtectionFlag == hex"01") {
-                return keccak256(abi.encode(address(this), block.chainid, salt));
-            }
-        } else if (senderBytes == address(0) && redeployProtectionFlag == hex"01") {
-            return _efficientHash({ a: bytes32(block.chainid), b: salt });
-        }
-
-        return keccak256(abi.encode(salt));
     }
 }

--- a/test/unit/DopplerCreateXDeployer.t.sol
+++ b/test/unit/DopplerCreateXDeployer.t.sol
@@ -4,12 +4,13 @@ pragma solidity ^0.8.24;
 import { Ownable } from "@solady/auth/Ownable.sol";
 import { ICreateX } from "createx/ICreateX.sol";
 import { Test } from "forge-std/Test.sol";
-import { DopplerDeployer } from "src/DopplerDeployer.sol";
+import { DopplerCreateXDeployer } from "src/DopplerCreateXDeployer.sol";
 
-contract DopplerDeployerTest is Test {
+contract DopplerCreateXDeployerTest is Test {
     event RolesUpdated(address indexed user, uint256 indexed roles);
     event AdminAdded(address admin);
     event AdminRemoved(address admin);
+    event RolesRevoked(address indexed addr);
     event DeployerAdded(address indexed admin, address deployer);
     event DeployerRemoved(address indexed admin, address deployer);
     event Deployed(address indexed deployer, address deployed);
@@ -25,7 +26,7 @@ contract DopplerDeployerTest is Test {
     address internal secondAuthorizedDeployer = makeAddr("secondAuthorizedDeployer");
     address internal stranger = makeAddr("stranger");
 
-    DopplerDeployer internal deployer;
+    DopplerCreateXDeployer internal deployer;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           SETUP                            */
@@ -33,7 +34,7 @@ contract DopplerDeployerTest is Test {
 
     function setUp() public {
         _etchCreateX();
-        deployer = new DopplerDeployer(owner);
+        deployer = new DopplerCreateXDeployer(owner);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -77,6 +78,45 @@ contract DopplerDeployerTest is Test {
         deployer.addAdmins(_addresses(admin));
     }
 
+    /// @notice Admins cannot grant admin roles.
+    function test_addAdmins_revertAdminCaller() public {
+        _addAdmin();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(admin);
+        deployer.addAdmins(_addresses(secondAdmin));
+    }
+
+    /// @notice Admin grants overwrite any existing deployer role instead of accumulating roles.
+    function test_addAdmins_replacesExistingDeployerRole() public {
+        vm.prank(owner);
+        deployer.addDeployers(_addresses(authorizedDeployer));
+
+        vm.prank(owner);
+        deployer.addAdmins(_addresses(authorizedDeployer));
+
+        assertEq(deployer.rolesOf(authorizedDeployer), ROLE_ADMIN);
+        assertTrue(deployer.hasAnyRole(authorizedDeployer, ROLE_ADMIN));
+        assertFalse(deployer.hasAnyRole(authorizedDeployer, ROLE_DEPLOYER));
+    }
+
+    /// @notice Zero address cannot receive admin roles.
+    function test_addAdmins_revertZeroAddress() public {
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAdmin.selector);
+
+        vm.prank(owner);
+        deployer.addAdmins(_addresses(address(0)));
+    }
+
+    /// @notice Owner cannot grant admin roles to itself.
+    function test_addAdmins_revertCallerAddress() public {
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAdmin.selector);
+
+        vm.prank(owner);
+        deployer.addAdmins(_addresses(owner));
+    }
+
     /// @notice Owner can remove admin roles and emit the expected events.
     function test_removeAdmins_ownerOnly_clearsRolesAndEmits() public {
         _addAdmins();
@@ -95,6 +135,224 @@ contract DopplerDeployerTest is Test {
 
         assertEq(deployer.rolesOf(admin), 0);
         assertEq(deployer.rolesOf(secondAdmin), 0);
+    }
+
+    /// @notice Non-owners cannot remove admin roles.
+    function test_removeAdmins_revertUnauthorized() public {
+        _addAdmin();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.removeAdmins(_addresses(admin));
+    }
+
+    /// @notice Admins cannot remove admin roles.
+    function test_removeAdmins_revertAdminCaller() public {
+        _addAdmins();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(admin);
+        deployer.removeAdmins(_addresses(secondAdmin));
+    }
+
+    /// @notice Zero address cannot be removed as an admin.
+    function test_removeAdmins_revertZeroAddress() public {
+        vm.prank(owner);
+        deployer.grantRoles(address(0), ROLE_ADMIN);
+
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAdmin.selector);
+
+        vm.prank(owner);
+        deployer.removeAdmins(_addresses(address(0)));
+    }
+
+    /// @notice Owner cannot remove itself as an admin through the admin wrapper.
+    function test_removeAdmins_revertCallerAddress() public {
+        vm.prank(owner);
+        deployer.grantRoles(owner, ROLE_ADMIN);
+
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAdmin.selector);
+
+        vm.prank(owner);
+        deployer.removeAdmins(_addresses(owner));
+    }
+
+    /// @notice Admin removal rejects targets without only admin role.
+    function test_removeAdmins_revertIfTargetIsNotAdmin() public {
+        _addAuthorizedDeployer();
+
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAdmin.selector);
+
+        vm.prank(owner);
+        deployer.removeAdmins(_addresses(authorizedDeployer));
+    }
+
+    /// @notice Owner can revoke all roles from admins and deployers.
+    function test_revokeRoles_ownerClearsAnyRoleAndEmits() public {
+        _addAuthorizedDeployer();
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, 0);
+        vm.expectEmit(true, false, false, false, address(deployer));
+        emit RolesRevoked(admin);
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(authorizedDeployer, 0);
+        vm.expectEmit(true, false, false, false, address(deployer));
+        emit RolesRevoked(authorizedDeployer);
+
+        vm.prank(owner);
+        deployer.revokeRoles(_addresses(admin, authorizedDeployer));
+
+        assertEq(deployer.rolesOf(admin), 0);
+        assertEq(deployer.rolesOf(authorizedDeployer), 0);
+    }
+
+    /// @notice Batch role revocation rejects addresses without existing roles.
+    function test_revokeRoles_revertAddressWithoutRoles() public {
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAddress.selector);
+
+        vm.prank(owner);
+        deployer.revokeRoles(_addresses(stranger));
+    }
+
+    /// @notice Non-owners cannot revoke arbitrary roles.
+    function test_revokeRoles_revertUnauthorized() public {
+        _addAdmin();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.revokeRoles(_addresses(admin));
+    }
+
+    /// @notice Admins cannot revoke arbitrary roles through the owner-only wrapper.
+    function test_revokeRoles_revertAdminCaller() public {
+        _addAuthorizedDeployer();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(admin);
+        deployer.revokeRoles(_addresses(authorizedDeployer));
+    }
+
+    /// @notice Zero address cannot be revoked through the batch wrapper.
+    function test_revokeRoles_revertZeroAddress() public {
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAddress.selector);
+
+        vm.prank(owner);
+        deployer.revokeRoles(_addresses(address(0)));
+    }
+
+    /// @notice Owner cannot revoke its own roles through the batch wrapper.
+    function test_revokeRoles_revertCallerAddress() public {
+        vm.expectRevert(DopplerCreateXDeployer.InvalidAddress.selector);
+
+        vm.prank(owner);
+        deployer.revokeRoles(_addresses(owner));
+    }
+
+    /// @notice Inherited role grants accumulate roles and emit inherited events.
+    function test_grantRoles_ownerAccumulatesRolesAndEmits() public {
+        uint256 roles = ROLE_ADMIN | ROLE_DEPLOYER;
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, roles);
+
+        vm.prank(owner);
+        deployer.grantRoles(admin, roles);
+
+        assertEq(deployer.rolesOf(admin), roles);
+        assertTrue(deployer.hasAnyRole(admin, ROLE_ADMIN));
+        assertTrue(deployer.hasAllRoles(admin, roles));
+    }
+
+    /// @notice Non-owner cannot call the inherited role grant.
+    function test_grantRoles_revertUnauthorized() public {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.grantRoles(admin, ROLE_ADMIN);
+    }
+
+    /// @notice Admins cannot call the inherited owner-only role grant.
+    function test_grantRoles_revertAdminCaller() public {
+        _addAdmin();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(admin);
+        deployer.grantRoles(secondAdmin, ROLE_ADMIN);
+    }
+
+    /// @notice Inherited role revocation removes only the selected role bits.
+    function test_revokeRoles_inheritedOwnerRemovesSelectedRoles() public {
+        uint256 roles = ROLE_ADMIN | ROLE_DEPLOYER;
+
+        vm.prank(owner);
+        deployer.grantRoles(admin, roles);
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, ROLE_ADMIN);
+
+        vm.prank(owner);
+        deployer.revokeRoles(admin, ROLE_DEPLOYER);
+
+        assertEq(deployer.rolesOf(admin), ROLE_ADMIN);
+        assertTrue(deployer.hasAnyRole(admin, ROLE_ADMIN));
+        assertFalse(deployer.hasAnyRole(admin, ROLE_DEPLOYER));
+        assertFalse(deployer.hasAllRoles(admin, roles));
+    }
+
+    /// @notice Non-owner cannot call the inherited role revocation.
+    function test_revokeRoles_inheritedRevertUnauthorized() public {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.revokeRoles(admin, ROLE_ADMIN);
+    }
+
+    /// @notice Admins cannot call the inherited owner-only role revocation.
+    function test_revokeRoles_inheritedRevertAdminCaller() public {
+        _addAdmin();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(admin);
+        deployer.revokeRoles(admin, ROLE_ADMIN);
+    }
+
+    /// @notice Callers can renounce their own inherited roles.
+    function test_renounceRoles_callerRemovesOwnRoles() public {
+        uint256 roles = ROLE_ADMIN | ROLE_DEPLOYER;
+
+        vm.prank(owner);
+        deployer.grantRoles(admin, roles);
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, ROLE_DEPLOYER);
+
+        vm.prank(admin);
+        deployer.renounceRoles(ROLE_ADMIN);
+
+        assertEq(deployer.rolesOf(admin), ROLE_DEPLOYER);
+    }
+
+    /// @notice Admin removal clears all roles when the target has mixed roles.
+    function test_removeAdmins_clearsInheritedMixedRoleTarget() public {
+        vm.prank(owner);
+        deployer.grantRoles(admin, ROLE_ADMIN | ROLE_DEPLOYER);
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(admin, 0);
+        vm.expectEmit(false, false, false, true, address(deployer));
+        emit AdminRemoved(admin);
+
+        vm.prank(owner);
+        deployer.removeAdmins(_addresses(admin));
+
+        assertEq(deployer.rolesOf(admin), 0);
     }
 
     /// @notice Admin can grant deployer roles and emit the expected events.
@@ -128,6 +386,18 @@ contract DopplerDeployerTest is Test {
         assertEq(deployer.rolesOf(secondAuthorizedDeployer), ROLE_DEPLOYER);
     }
 
+    /// @notice Deployer grants overwrite any existing admin role instead of accumulating roles.
+    function test_addDeployers_replacesExistingAdminRole() public {
+        _addAdmins();
+
+        vm.prank(owner);
+        deployer.addDeployers(_addresses(secondAdmin));
+
+        assertEq(deployer.rolesOf(secondAdmin), ROLE_DEPLOYER);
+        assertFalse(deployer.hasAnyRole(secondAdmin, ROLE_ADMIN));
+        assertTrue(deployer.hasAnyRole(secondAdmin, ROLE_DEPLOYER));
+    }
+
     /// @notice Unauthorized callers cannot grant deployer roles.
     function test_addDeployers_revertUnauthorized() public {
         vm.expectRevert(Ownable.Unauthorized.selector);
@@ -136,9 +406,19 @@ contract DopplerDeployerTest is Test {
         deployer.addDeployers(_addresses(authorizedDeployer));
     }
 
+    /// @notice Deployer-role callers cannot grant deployer roles.
+    function test_addDeployers_revertDeployerCaller() public {
+        _addAuthorizedDeployer();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(authorizedDeployer);
+        deployer.addDeployers(_addresses(secondAuthorizedDeployer));
+    }
+
     /// @notice Zero address cannot receive deployer roles.
     function test_addDeployers_revertZeroAddress() public {
-        vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
+        vm.expectRevert(DopplerCreateXDeployer.InvalidDeployer.selector);
 
         vm.prank(owner);
         deployer.addDeployers(_addresses(address(0)));
@@ -146,20 +426,10 @@ contract DopplerDeployerTest is Test {
 
     /// @notice Caller cannot grant deployer roles to itself.
     function test_addDeployers_revertCallerAddress() public {
-        vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
+        vm.expectRevert(DopplerCreateXDeployer.InvalidDeployer.selector);
 
         vm.prank(owner);
         deployer.addDeployers(_addresses(owner));
-    }
-
-    /// @notice Addresses with any existing role cannot receive deployer roles.
-    function test_addDeployers_revertRoleAlreadyAssigned() public {
-        _addAdmin();
-
-        vm.expectRevert(DopplerDeployer.RoleAlreadyAssigned.selector);
-
-        vm.prank(owner);
-        deployer.addDeployers(_addresses(admin));
     }
 
     /// @notice Admin can revoke deployer roles and emit the expected events.
@@ -203,14 +473,62 @@ contract DopplerDeployerTest is Test {
         deployer.removeDeployers(_addresses(authorizedDeployer));
     }
 
+    /// @notice Deployer-role callers cannot revoke deployer roles.
+    function test_removeDeployers_revertDeployerCaller() public {
+        _addAuthorizedDeployers();
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(authorizedDeployer);
+        deployer.removeDeployers(_addresses(secondAuthorizedDeployer));
+    }
+
     /// @notice Deployer removal rejects targets without only deployer role.
     function test_removeDeployers_revertIfTargetIsNotDeployer() public {
         _addAdmin();
 
-        vm.expectRevert(DopplerDeployer.InvalidDeployer.selector);
+        vm.expectRevert(DopplerCreateXDeployer.InvalidDeployer.selector);
 
         vm.prank(owner);
         deployer.removeDeployers(_addresses(admin));
+    }
+
+    /// @notice Deployer removal clears all roles when the target has mixed roles.
+    function test_removeDeployers_clearsInheritedMixedRoleTarget() public {
+        vm.prank(owner);
+        deployer.grantRoles(authorizedDeployer, ROLE_ADMIN | ROLE_DEPLOYER);
+
+        vm.expectEmit(true, true, false, false, address(deployer));
+        emit RolesUpdated(authorizedDeployer, 0);
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit DeployerRemoved(owner, authorizedDeployer);
+
+        vm.prank(owner);
+        deployer.removeDeployers(_addresses(authorizedDeployer));
+
+        assertEq(deployer.rolesOf(authorizedDeployer), 0);
+    }
+
+    /// @notice Zero address cannot be removed as a deployer.
+    function test_removeDeployers_revertZeroAddress() public {
+        vm.prank(owner);
+        deployer.grantRoles(address(0), ROLE_DEPLOYER);
+
+        vm.expectRevert(DopplerCreateXDeployer.InvalidDeployer.selector);
+
+        vm.prank(owner);
+        deployer.removeDeployers(_addresses(address(0)));
+    }
+
+    /// @notice Owner caller cannot remove itself through the deployer removal wrapper.
+    function test_removeDeployers_revertCallerAddress() public {
+        vm.prank(owner);
+        deployer.grantRoles(owner, ROLE_DEPLOYER);
+
+        vm.expectRevert(DopplerCreateXDeployer.InvalidDeployer.selector);
+
+        vm.prank(owner);
+        deployer.removeDeployers(_addresses(owner));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -219,9 +537,9 @@ contract DopplerDeployerTest is Test {
 
     /// @notice Generated salts are deployer-keyed with name and version entropy.
     function test_generateSalt_usesDeployerAddressAndNameVersionEntropy() public view {
-        bytes32 salt = deployer.generateSalt("DopplerDeployer", 2);
+        bytes32 salt = deployer.generateSalt("DopplerCreateXDeployer", 2);
         bytes32 expected = bytes32(uint256(uint160(address(deployer))) << 96)
-            | bytes32(uint256(keccak256(abi.encode("DopplerDeployer", uint256(2)))) >> 168);
+            | bytes32(uint256(keccak256(abi.encode("DopplerCreateXDeployer", uint256(2)))) >> 168);
 
         assertEq(salt, expected);
         assertEq(address(bytes20(salt)), address(deployer));
@@ -296,16 +614,19 @@ contract DopplerDeployerTest is Test {
         bytes memory initCode = _deployableInitCode(42);
         bytes32 salt = deployer.generateSalt("Create2Owner", 1);
         address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+        vm.deal(owner, 1 ether);
 
         vm.expectEmit(true, false, false, true, address(deployer));
         emit Deployed(owner, expected);
 
         vm.prank(owner);
-        address deployed = deployer.deployCreate2(salt, initCode);
+        address deployed = deployer.deployCreate2{ value: 0.1 ether }(salt, initCode);
 
         assertEq(deployed, expected);
         assertEq(DeployableContract(deployed).value(), 42);
+        assertEq(DeployableContract(deployed).constructorValue(), 0.1 ether);
         assertEq(DeployableContract(deployed).constructorSender(), CREATEX);
+        assertEq(deployed.balance, 0.1 ether);
     }
 
     /// @notice Deployer role can deploy with default salt and expected-address check.
@@ -315,12 +636,33 @@ contract DopplerDeployerTest is Test {
         bytes memory initCode = _deployableInitCode(43);
         bytes32 salt = deployer.generateSalt("Create2Expected", 1);
         address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+        vm.deal(authorizedDeployer, 1 ether);
+
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit Deployed(authorizedDeployer, expected);
 
         vm.prank(authorizedDeployer);
-        address deployed = deployer.deployCreate2(salt, initCode, expected);
+        address deployed = deployer.deployCreate2{ value: 0.2 ether }(salt, initCode, expected);
 
         assertEq(deployed, expected);
         assertEq(DeployableContract(deployed).value(), 43);
+        assertEq(DeployableContract(deployed).constructorValue(), 0.2 ether);
+        assertEq(deployed.balance, 0.2 ether);
+    }
+
+    /// @notice Admin role can deploy with Create2 through the authorized deployment surface.
+    function test_deployCreate2_adminRoleDeploysToComputedAddress() public {
+        _addAdmin();
+
+        bytes memory initCode = _deployableInitCode(54);
+        bytes32 salt = deployer.generateSalt("Create2Admin", 1);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.prank(admin);
+        address deployed = deployer.deployCreate2(salt, initCode);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 54);
     }
 
     /// @notice Create2 deployment for deployer-keyed salts with redeploy protection.
@@ -369,7 +711,7 @@ contract DopplerDeployerTest is Test {
         address actual = deployer.computeCreate2Address(salt, keccak256(initCode));
         address wrongExpected = makeAddr("wrongExpected");
 
-        vm.expectRevert(abi.encodeWithSelector(DopplerDeployer.AddressMismatch.selector, actual, wrongExpected));
+        vm.expectRevert(abi.encodeWithSelector(DopplerCreateXDeployer.AddressMismatch.selector, actual, wrongExpected));
 
         vm.prank(owner);
         deployer.deployCreate2(salt, initCode, wrongExpected);
@@ -388,6 +730,18 @@ contract DopplerDeployerTest is Test {
         deployer.deployCreate2(salt, initCode);
     }
 
+    /// @notice Unauthorized callers cannot deploy with Create2 expected-address checks.
+    function test_deployCreate2Expected_revertUnauthorized() public {
+        bytes memory initCode = _deployableInitCode(1);
+        bytes32 salt = deployer.generateSalt("ExpectedUnauthorized", 1);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.deployCreate2(salt, initCode, expected);
+    }
+
     /// @notice Invalid Create2 salts revert from CreateX.
     function test_deployCreate2_revertInvalidSaltFromCreateX() public {
         bytes32 salt = _salt(address(deployer), 2, 0x1234);
@@ -396,6 +750,21 @@ contract DopplerDeployerTest is Test {
 
         vm.prank(owner);
         deployer.deployCreate2(salt, _deployableInitCode(1));
+    }
+
+    /// @notice Create2 forwards constructor value and CreateX rejects non-payable init code.
+    function test_deployCreate2_revertNonPayableConstructorWithValue() public {
+        bytes memory initCode = type(NonPayableDeployableContract).creationCode;
+        bytes32 salt = deployer.generateSalt("Create2NonPayable", 1);
+        address expected = deployer.computeCreate2Address(salt, keccak256(initCode));
+        vm.deal(owner, 1 wei);
+
+        vm.expectRevert(abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, CREATEX));
+
+        vm.prank(owner);
+        deployer.deployCreate2{ value: 1 wei }(salt, initCode);
+
+        assertEq(expected.code.length, 0);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -407,15 +776,18 @@ contract DopplerDeployerTest is Test {
         bytes memory initCode = _deployableInitCode(45);
         bytes32 salt = deployer.generateSalt("Create3Owner", 1);
         address expected = deployer.computeCreate3Address(salt);
+        vm.deal(owner, 1 ether);
 
         vm.expectEmit(true, false, false, true, address(deployer));
         emit Deployed(owner, expected);
 
         vm.prank(owner);
-        address deployed = deployer.deployCreate3(salt, initCode);
+        address deployed = deployer.deployCreate3{ value: 0.3 ether }(salt, initCode);
 
         assertEq(deployed, expected);
         assertEq(DeployableContract(deployed).value(), 45);
+        assertEq(DeployableContract(deployed).constructorValue(), 0.3 ether);
+        assertEq(deployed.balance, 0.3 ether);
     }
 
     /// @notice Deployer role can deploy with Create3 and expected-address check.
@@ -425,12 +797,33 @@ contract DopplerDeployerTest is Test {
         bytes memory initCode = _deployableInitCode(46);
         bytes32 salt = deployer.generateSalt("Create3Expected", 1);
         address expected = deployer.computeCreate3Address(salt);
+        vm.deal(authorizedDeployer, 1 ether);
+
+        vm.expectEmit(true, false, false, true, address(deployer));
+        emit Deployed(authorizedDeployer, expected);
 
         vm.prank(authorizedDeployer);
-        address deployed = deployer.deployCreate3(salt, initCode, expected);
+        address deployed = deployer.deployCreate3{ value: 0.4 ether }(salt, initCode, expected);
 
         assertEq(deployed, expected);
         assertEq(DeployableContract(deployed).value(), 46);
+        assertEq(DeployableContract(deployed).constructorValue(), 0.4 ether);
+        assertEq(deployed.balance, 0.4 ether);
+    }
+
+    /// @notice Admin role can deploy with Create3 through the authorized deployment surface.
+    function test_deployCreate3_adminRoleDeploysToComputedAddress() public {
+        _addAdmin();
+
+        bytes memory initCode = _deployableInitCode(55);
+        bytes32 salt = deployer.generateSalt("Create3Admin", 1);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.prank(admin);
+        address deployed = deployer.deployCreate3(salt, initCode);
+
+        assertEq(deployed, expected);
+        assertEq(DeployableContract(deployed).value(), 55);
     }
 
     /// @notice Create3 deployment for deployer-keyed salts with redeploy protection.
@@ -479,12 +872,34 @@ contract DopplerDeployerTest is Test {
         address actual = deployer.computeCreate3Address(salt);
         address wrongExpected = makeAddr("wrongExpected");
 
-        vm.expectRevert(abi.encodeWithSelector(DopplerDeployer.AddressMismatch.selector, actual, wrongExpected));
+        vm.expectRevert(abi.encodeWithSelector(DopplerCreateXDeployer.AddressMismatch.selector, actual, wrongExpected));
 
         vm.prank(owner);
         deployer.deployCreate3(salt, initCode, wrongExpected);
 
         assertEq(actual.code.length, 0);
+    }
+
+    /// @notice Unauthorized callers cannot deploy with Create3.
+    function test_deployCreate3_revertUnauthorized() public {
+        bytes32 salt = deployer.generateSalt("Create3Unauthorized", 1);
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.deployCreate3(salt, _deployableInitCode(1));
+    }
+
+    /// @notice Unauthorized callers cannot deploy with Create3 expected-address checks.
+    function test_deployCreate3Expected_revertUnauthorized() public {
+        bytes memory initCode = _deployableInitCode(1);
+        bytes32 salt = deployer.generateSalt("Create3ExpectedUnauthorized", 1);
+        address expected = deployer.computeCreate3Address(salt);
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.deployCreate3(salt, initCode, expected);
     }
 
     /// @notice Invalid Create3 salts revert from CreateX.
@@ -493,6 +908,20 @@ contract DopplerDeployerTest is Test {
 
         vm.prank(owner);
         deployer.deployCreate3(_salt(address(deployer), 2, 0x1234), _deployableInitCode(1));
+    }
+
+    /// @notice Create3 forwards constructor value and CreateX rejects non-payable init code.
+    function test_deployCreate3_revertNonPayableConstructorWithValue() public {
+        bytes32 salt = deployer.generateSalt("Create3NonPayable", 1);
+        address expected = deployer.computeCreate3Address(salt);
+        vm.deal(owner, 1 wei);
+
+        vm.expectRevert(abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, CREATEX));
+
+        vm.prank(owner);
+        deployer.deployCreate3{ value: 1 wei }(salt, type(NonPayableDeployableContract).creationCode);
+
+        assertEq(expected.code.length, 0);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -514,6 +943,18 @@ contract DopplerDeployerTest is Test {
         assertEq(target.received(), 0.25 ether);
     }
 
+    /// @notice Admin role can execute through the authorized execution surface.
+    function test_execute_singleCallAdminCanExecute() public {
+        CallTarget target = new CallTarget();
+        _addAdmin();
+
+        vm.prank(admin);
+        bytes memory result = deployer.execute(address(target), abi.encodeCall(CallTarget.store, (12)));
+
+        assertEq(abi.decode(result, (uint256)), 13);
+        assertEq(target.value(), 12);
+    }
+
     /// @notice Unauthorized callers cannot execute a single call.
     function test_execute_singleCallRevertUnauthorized() public {
         CallTarget target = new CallTarget();
@@ -528,7 +969,7 @@ contract DopplerDeployerTest is Test {
     function test_execute_singleCallRevertExecutionFailed() public {
         CallTarget target = new CallTarget();
 
-        vm.expectRevert(DopplerDeployer.ExecutionFailed.selector);
+        vm.expectRevert(DopplerCreateXDeployer.ExecutionFailed.selector);
 
         vm.prank(owner);
         deployer.execute(address(target), abi.encodeCall(CallTarget.fail, ()));
@@ -563,13 +1004,77 @@ contract DopplerDeployerTest is Test {
         assertEq(second.received(), 2 wei);
     }
 
+    /// @notice Admin and deployer roles can execute batches through the authorized execution surface.
+    function test_execute_batchAdminAndDeployerCanExecute() public {
+        CallTarget adminTarget = new CallTarget();
+        CallTarget deployerTarget = new CallTarget();
+        _addAuthorizedDeployer();
+
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory data = new bytes[](1);
+
+        targets[0] = address(adminTarget);
+        data[0] = abi.encodeCall(CallTarget.store, (40));
+
+        vm.prank(admin);
+        bytes[] memory adminResults = deployer.execute(targets, values, data);
+
+        targets[0] = address(deployerTarget);
+        data[0] = abi.encodeCall(CallTarget.store, (50));
+
+        vm.prank(authorizedDeployer);
+        bytes[] memory deployerResults = deployer.execute(targets, values, data);
+
+        assertEq(abi.decode(adminResults[0], (uint256)), 41);
+        assertEq(adminTarget.value(), 40);
+        assertEq(abi.decode(deployerResults[0], (uint256)), 51);
+        assertEq(deployerTarget.value(), 50);
+    }
+
+    /// @notice Authorized batch execution supports empty batches.
+    function test_execute_batchAllowsEmptyCalls() public {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory data = new bytes[](0);
+
+        vm.prank(owner);
+        bytes[] memory results = deployer.execute(targets, values, data);
+
+        assertEq(results.length, 0);
+    }
+
+    /// @notice Unauthorized callers cannot execute batch calls.
+    function test_execute_batchRevertUnauthorized() public {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory data = new bytes[](0);
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+
+        vm.prank(stranger);
+        deployer.execute(targets, values, data);
+    }
+
     /// @notice Batch execution rejects mismatched input array lengths.
-    function test_execute_batchRevertArrayLengthMismatch() public {
+    function test_execute_batchRevertValueArrayLengthMismatch() public {
         address[] memory targets = new address[](1);
         uint256[] memory values = new uint256[](2);
         bytes[] memory data = new bytes[](1);
 
-        vm.expectRevert(DopplerDeployer.ArrayLengthsMismatch.selector);
+        vm.expectRevert(DopplerCreateXDeployer.ArrayLengthsMismatch.selector);
+
+        vm.prank(owner);
+        deployer.execute(targets, values, data);
+    }
+
+    /// @notice Batch execution rejects mismatched calldata array length.
+    function test_execute_batchRevertDataArrayLengthMismatch() public {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory data = new bytes[](2);
+
+        vm.expectRevert(DopplerCreateXDeployer.ArrayLengthsMismatch.selector);
 
         vm.prank(owner);
         deployer.execute(targets, values, data);
@@ -593,7 +1098,7 @@ contract DopplerDeployerTest is Test {
         data[0] = abi.encodeCall(CallTarget.store, (20));
         data[1] = abi.encodeCall(CallTarget.store, (30));
 
-        vm.expectRevert(abi.encodeWithSelector(DopplerDeployer.PaymentMismatch.selector, 3, 2));
+        vm.expectRevert(abi.encodeWithSelector(DopplerCreateXDeployer.PaymentMismatch.selector, 3, 2));
 
         vm.prank(owner);
         deployer.execute{ value: 3 wei }(targets, values, data);
@@ -614,7 +1119,7 @@ contract DopplerDeployerTest is Test {
         bytes[] memory data = new bytes[](1);
         data[0] = abi.encodeCall(CallTarget.fail, ());
 
-        vm.expectRevert(DopplerDeployer.ExecutionFailed.selector);
+        vm.expectRevert(DopplerCreateXDeployer.ExecutionFailed.selector);
 
         vm.prank(owner);
         deployer.execute(targets, values, data);
@@ -694,13 +1199,17 @@ contract DopplerDeployerTest is Test {
 
 contract DeployableContract {
     uint256 public immutable value;
+    uint256 public immutable constructorValue;
     address public immutable constructorSender;
 
     constructor(uint256 value_) payable {
         value = value_;
+        constructorValue = msg.value;
         constructorSender = msg.sender;
     }
 }
+
+contract NonPayableDeployableContract { }
 
 contract CallTarget {
     error TargetFailed();


### PR DESCRIPTION
## Description

Adds the initial MVP for the Doppler deployment-script overhaul, centered around a reusable `DeployBase`, a top-level `DeployDopplerScript`, and standalone scripts for bootstrapping the protocol's `Deployer` and deploying `Airlock`.

## Motivation

We want one primary entrypoint for full protocol deployments to new chains while preserving the ability to run individual deployment scripts for contract updates. This commit establishes the script structure, shared helpers, and address-safety checks that the remaining deployment scripts can follow.

## Changes

- Added `script/deploy/DeployBase.s.sol` with shared config loading, fork selection, deployment context, config writes, CREATE3 deploy/reuse helpers, and guarded salt address verification.
- Added `script/DeployDoppler.s.sol` as the aggregate deployment entrypoint with chain-specific child scripts.
- Added `script/DeployDeployer.s.sol` to bootstrap the protocol deployer separately.
- Refactored `script/deploy/DeployAirlock.s.sol` to support both standalone and aggregate deployment flows.
- Added `script/utils/Versions.sol` for versioned deployment salts.
- Renamed `DopplerDeployer` to `Deployer` and updated the matching unit test file.
- Moved the previous `Airlock` deploy script to `legacy/script/deploy/DeployAirlock.s.sol`.