### PR TITLE
feat: all deploy scripts overhauled

### DIFF
--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -1,0 +1,219 @@
+name: Deploy Contracts
+
+on:
+  workflow_dispatch:
+    inputs:
+      script_name:
+        description: "Foundry script name, for example DeployDopplerScriptBase"
+        required: true
+        type: string
+      broadcast:
+        description: "Broadcast (simulate if unchecked)"
+        required: true
+        default: false
+        type: boolean
+      rpc_url:
+        description: "Optional RPC URL for scripts that do not select a fork internally"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-contracts-${{ github.ref }}-${{ inputs.script_name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: ${{ inputs.broadcast && 'Broadcast' || 'Simulate' }} ${{ inputs.script_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Show Forge version
+        run: forge --version
+
+      - name: Resolve deployer address
+        id: deployer
+        shell: bash
+        env:
+          DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DEPLOYER_PRIVATE_KEY:-}" ]]; then
+            echo "::error::DEPLOYER_PRIVATE_KEY secret is required."
+            exit 1
+          fi
+
+          echo "::add-mask::$DEPLOYER_PRIVATE_KEY"
+          deployer_address="$(cast wallet address --private-key "$DEPLOYER_PRIVATE_KEY")"
+          echo "address=$deployer_address" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve script file
+        id: script
+        shell: bash
+        env:
+          SCRIPT_NAME: ${{ inputs.script_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$SCRIPT_NAME" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "::error::script_name must be a Solidity contract identifier."
+            exit 1
+          fi
+
+          matches=()
+          while IFS= read -r -d '' file; do
+            if grep -Eq "contract[[:space:]]+$SCRIPT_NAME([^A-Za-z0-9_]|$)" "$file"; then
+              matches+=("$file")
+            fi
+          done < <(find script -name '*.s.sol' -print0)
+
+          if [[ "${#matches[@]}" -eq 0 ]]; then
+            echo "::error::No script contract named $SCRIPT_NAME was found under script/."
+            exit 1
+          fi
+
+          if [[ "${#matches[@]}" -gt 1 ]]; then
+            printf '::error::Script contract name %s is ambiguous. Matches:\n' "$SCRIPT_NAME"
+            printf '%s\n' "${matches[@]}"
+            exit 1
+          fi
+
+          echo "file=${matches[0]}" >> "$GITHUB_OUTPUT"
+          echo "Resolved $SCRIPT_NAME to ${matches[0]}"
+
+      - name: Build scripts
+        run: forge build ./script --via-ir
+
+      - name: Run deployment script
+        shell: bash
+        env:
+          BROADCAST: ${{ inputs.broadcast }}
+          DEPLOYER_ADDRESS: ${{ steps.deployer.outputs.address }}
+          DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+          ETH_MAINNET_RPC_URL: ${{ secrets.ETH_MAINNET_RPC_URL }}
+          ETH_SEPOLIA_RPC_URL: ${{ secrets.ETH_SEPOLIA_RPC_URL }}
+          MONAD_MAINNET_RPC_URL: ${{ secrets.MONAD_MAINNET_RPC_URL }}
+          MONAD_TESTNET_RPC_URL: ${{ secrets.MONAD_TESTNET_RPC_URL }}
+          BASE_MAINNET_RPC_URL: ${{ secrets.BASE_MAINNET_RPC_URL }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
+          UNICHAIN_MAINNET_RPC_URL: ${{ secrets.UNICHAIN_MAINNET_RPC_URL }}
+          UNICHAIN_SEPOLIA_RPC_URL: ${{ secrets.UNICHAIN_SEPOLIA_RPC_URL }}
+          MEGAETH_MAINNET_RPC_URL: ${{ secrets.MEGAETH_MAINNET_RPC_URL }}
+          MEGAETH_TESTNET_RPC_URL: ${{ secrets.MEGAETH_TESTNET_RPC_URL }}
+          RPC_URL: ${{ inputs.rpc_url }}
+          SCRIPT_NAME: ${{ inputs.script_name }}
+          SCRIPT_FILE: ${{ steps.script.outputs.file }}
+        run: |
+          set -euo pipefail
+
+          forge_args=(
+            --target-contract "$SCRIPT_NAME"
+            --private-key "$DEPLOYER_PRIVATE_KEY"
+            --sender "$DEPLOYER_ADDRESS"
+            --non-interactive
+            -vvv
+          )
+
+          if [[ -n "$RPC_URL" ]]; then
+            forge_args+=(--rpc-url "$RPC_URL")
+          fi
+
+          if [[ "$BROADCAST" == "true" ]]; then
+            forge_args+=(--broadcast --slow)
+          fi
+
+          forge script "${forge_args[@]}" "$SCRIPT_FILE"
+
+      - name: Generate deployment history
+        if: ${{ inputs.broadcast }}
+        run: |
+          touch .env
+          make generate-history
+
+      - name: Upload deployment artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: deployment-artifacts
+          if-no-files-found: ignore
+          path: |
+            broadcast/
+            deployments.config.toml
+            Deployments.md
+            Deployments.json
+            deployments/*.md
+
+  create-pr:
+    name: Open deployment records PR
+    if: ${{ inputs.broadcast }}
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Download deployment artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: deployment-artifacts
+          path: .
+
+      - name: Create deployment record pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCRIPT_NAME: ${{ inputs.script_name }}
+          BRANCH_NAME: deploy-contracts/${{ inputs.script_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          BASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
+
+          git add broadcast/ deployments.config.toml Deployments.md Deployments.json deployments/*.md
+
+          if git diff --cached --quiet; then
+            echo "No deployment record changes to commit."
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+          git commit -m "Record deployments for $SCRIPT_NAME"
+          git push --set-upstream origin "$BRANCH_NAME"
+
+          cat > /tmp/pr-body.md <<EOF
+          Records the deployment output from \`$SCRIPT_NAME\`.
+
+          This PR was generated by the Deploy Contracts workflow after a broadcast run.
+          EOF
+
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH_NAME" \
+            --title "Record deployments for $SCRIPT_NAME" \
+            --body-file /tmp/pr-body.md

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ FEE=30
 
 ### Deploying
 
-Deployment scripts for individual modules and operational tasks live in the [script](/script) folder. Configure the required environment variables in `.env`, then run the relevant script directly with `forge script`.
+See the deployment documentation in [docs/Deployment.md](/docs/Deployment.md). Configure the required environment variables in `.env` or GitHub, and then run the relevant deployment script directly with `forge script`.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,0 +1,65 @@
+### Deployment
+
+The supported top-level deployment entry point is [`script/DeployDoppler.s.sol`](../script/DeployDoppler.s.sol). It deploys or reuses the versioned contracts controlled by [`script/utils/Versions.sol`](../script/utils/Versions.sol), writes deployment outputs back to [`deployments.config.toml`](../deployments.config.toml) during broadcast runs, and can be rerun after bumping only the versions that need new deployments. Individual scripts in [`script/deploy`](../script/deploy) can still be run directly when deploying one contract at a time.
+
+The current target chains are:
+
+| Chain        | Chain ID | Top-level script                 | Testnet |
+| ------------ | -------: | -------------------------------- | ------- |
+| Ethereum     |      `1` | `DeployDopplerScriptEthereum`    | `false` |
+| Monad        |    `143` | `DeployDopplerScriptMonad`       | `false` |
+| Base         |   `8453` | `DeployDopplerScriptBase`        | `false` |
+| Base Sepolia |  `84532` | `DeployDopplerScriptBaseSepolia` | `true`  |
+
+To add another target chain, add the chain ID to [`script/utils/ChainIds.sol`](../script/utils/ChainIds.sol), add an explicit wrapper contract in `DeployDoppler.s.sol` that calls `_setUpChain(chainId, isTestnet)`, add a complete chain section to `deployments.config.toml`, and configure the target RPC in both [`foundry.toml`](../foundry.toml) and `deployments.config.toml`.
+
+Deployment configuration:
+
+RPC configuration has one environment value and two repository references:
+
+- `.env`: set the actual RPC URL environment variable, for example `BASE_MAINNET_RPC_URL=...`.
+- `[rpc_endpoints]` in `foundry.toml`: map a Foundry RPC alias to that environment variable, for example `base = "${BASE_MAINNET_RPC_URL}"`. Use this alias for CLI commands that pass `--rpc-url <foundry-rpc-alias>`.
+- `[chain] endpoint_url` in `deployments.config.toml`: reference the same environment variable for that chain, for example `[8453] endpoint_url = "${BASE_MAINNET_RPC_URL}"`. Chain-specific top-level wrappers use this value when selecting their fork.
+
+Keep the `foundry.toml` alias and the `deployments.config.toml` `endpoint_url` reference aligned for each chain so bootstrap, standalone, and aggregate deployment commands all run against the same RPC.
+
+Required chain config in `deployments.config.toml`:
+
+- `[chain] endpoint_url`: RPC endpoint environment reference used by the chain-specific top-level deployment wrappers.
+- `[chain.bool] is_testnet`: `true` only for chains that should deploy `AirlockMultisigTestnet` before `Airlock`.
+- `[chain.address] deployer_owner`: owner for the `DopplerCreateXDeployer` bootstrap deployment.
+- `[chain.address] protocol_deployer`: populated after `DeployDopplerCreateXDeployerScript` is broadcast.
+- `[chain.address] airlock_multisig`: required for non-testnets. Testnets deploy and write this through `DeployAirlockMultisigTestnet`.
+- `[chain.address] uniswap_v4_pool_manager`
+- `[chain.address] uniswap_v3_factory`
+- `[chain.address] uniswap_v2_factory`
+- `[chain.address] weth`
+- `[chain.address] quoter_v2`
+- `[chain.address] quoter_v4`
+- `[chain.address] universal_router`
+- `[chain.address] uniswap_v4_state_view`
+
+Deployment flow:
+
+1. Configure the target chain RPC in all three places: set the environment variable in `.env`, map it under `[rpc_endpoints]` in `foundry.toml`, and reference it as `[chain] endpoint_url` in `deployments.config.toml`. Add a `DeployDopplerScript` wrapper if this is a new supported chain. If deploying new protocol versions on an existing chain, update the relevant constants in `Versions.sol`.
+2. Configure `salt` and `expectedAddress` in `DeployDopplerCreateXDeployerScript`, set `deployer_owner`, then broadcast the bootstrap deployer script. A successful broadcast writes `protocol_deployer` to the active chain config.
+
+   ```shell
+   forge script script/DeployDopplerCreateXDeployer.s.sol:DeployDopplerCreateXDeployerScript --rpc-url <foundry-rpc-alias> --broadcast
+   ```
+
+3. Authorize the account that will broadcast `DeployDopplerScript`. The `protocol_deployer` owner is already authorized; otherwise the owner or an admin should call `addDeployers(address[])` on `DopplerCreateXDeployer`.
+
+   ```shell
+   cast send <protocol_deployer> "addDeployers(address[])" "[<broadcaster>]" --rpc-url <rpc-url> --private-key <owner-or-admin-private-key>
+   ```
+
+4. Broadcast the top-level deployment script for the target chain. The chain-specific wrapper selects the configured fork for its chain ID.
+
+   ```shell
+   forge script script/DeployDoppler.s.sol:DeployDopplerScriptBase --broadcast
+   ```
+
+For standalone contract deployments, run the specific script from `script/deploy` with the target chain RPC context after `protocol_deployer` is configured and the broadcaster is authorized. Individual deploy scripts also expose chain-specific wrappers named like `<DeployScriptName>Ethereum`, `<DeployScriptName>Monad`, `<DeployScriptName>Base`, and `<DeployScriptName>BaseSepolia`, which select the configured RPC endpoint internally. `DeployAirlockMultisigTestnetScript` is testnet-only and exposes only `DeployAirlockMultisigTestnetScriptBaseSepolia`.
+
+The same scripts can be run from the **Deploy Contracts** GitHub Action. Enter the Solidity script contract name, such as `DeployDopplerScriptBase`, and leave **Broadcast (simulate if unchecked)** disabled for a dry-run simulation. The action resolves the matching foundry script, derives the deployer address from the `DEPLOYER_PRIVATE_KEY` repository secret, and passes both `--private-key` and `--sender` so default `vm.startBroadcast()` calls use the deployer account in simulations and broadcasts. Chain-specific wrappers use the RPC environment variable configured in `deployments.config.toml`, so the matching RPC URL secret must exist in GitHub; standalone scripts that call `_loadConfigForCurrentChain()` should use the optional RPC alias/URL input. After broadcast runs, the action runs `make generate-history` and opens a pull request for any changed broadcast logs, `deployments.config.toml`, and generated deployment docs using GitHub's built-in `GITHUB_TOKEN`.

--- a/legacy/script/deploy/DeployAirlockMultisigTestnet.s.sol
+++ b/legacy/script/deploy/DeployAirlockMultisigTestnet.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { AirlockMultisigTestnet } from "script/utils/AirlockMultisigTestnet.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeGuardedSalt } from "test/shared/AirlockMiner.sol";
+
+contract DeployAirlockMultisigTestnetScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](1);
+        targets[0] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToTestnetChain(chainId);
+        }
+    }
+
+    function deployToTestnetChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        // We only deploy this multisig on testnets
+        if (config.get("is_testnet").toBool() == false) {
+            return;
+        }
+
+        address createX = config.get("create_x").toAddress();
+
+        vm.startBroadcast();
+
+        bytes32 salt = bytes32(uint256(uint160(msg.sender)) << 96 | 0xdeadbeef);
+        address expectedAddress = computeCreate3Address(computeGuardedSalt(salt, msg.sender), address(createX));
+
+        address[] memory signers = new address[](5);
+        signers[0] = msg.sender;
+        signers[1] = 0x88C23B886580FfAd04C66055edB6c777f5F74a08;
+        signers[2] = 0x00D1C1c523D0058359850F8A1E49504ef78541cE;
+        signers[3] = 0xdF95Cc445469816234Ad95f702c79d25BCE401a7;
+        signers[4] = 0xD877ca966bA431102B6aB217A899fa686D7Fa639;
+
+        address airlockMultisigTestnet = ICreateX(createX)
+            .deployCreate3(salt, abi.encodePacked(type(AirlockMultisigTestnet).creationCode, abi.encode(signers)));
+        require(airlockMultisigTestnet == expectedAddress, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        config.set("airlock_multisig", airlockMultisigTestnet);
+    }
+}

--- a/legacy/script/deploy/DeployBundler.s.sol
+++ b/legacy/script/deploy/DeployBundler.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { Airlock } from "src/Airlock.sol";
+import { Bundler } from "src/Bundler.sol";
+
+contract DeployBundlerScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](2);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address airlock = config.get("airlock").toAddress();
+        address quoterV2 = config.get("quoter_v2").toAddress();
+        address quoterV4 = config.get("quoter_v4").toAddress();
+        address router = config.get("universal_router").toAddress();
+        address createX = config.get("create_x").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(Bundler).name);
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address bundler = ICreateX(createX)
+            .deployCreate3(
+                salt, abi.encodePacked(type(Bundler).creationCode, abi.encode(airlock, router, quoterV2, quoterV4))
+            );
+        require(bundler == expectedAddress, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("bundler", bundler);
+    }
+}

--- a/legacy/script/deploy/DeployDN404Factory.s.sol
+++ b/legacy/script/deploy/DeployDN404Factory.s.sol
@@ -8,9 +8,7 @@ import { ChainIds, checkChainId } from "script/utils/ChainIds.sol";
 import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
 import { DN404Factory } from "src/tokens/DN404Factory.sol";
 
-contract DeployDN404FactoryV2BaseSepoliaScript is Script, Config {
-    string internal constant SALT_NAME = "DN404Factory-2";
-
+contract DeployDN404FactoryBaseSepoliaScript is Script, Config {
     function run() public {
         checkChainId(ChainIds.BASE_SEPOLIA);
         _loadConfig("./deployments.config.toml", true);
@@ -20,7 +18,7 @@ contract DeployDN404FactoryV2BaseSepoliaScript is Script, Config {
 
         vm.startBroadcast();
         address deployer = tx.origin;
-        bytes32 salt = generateCreate3Salt(deployer, SALT_NAME);
+        bytes32 salt = generateCreate3Salt(deployer, type(DN404Factory).name);
         address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, deployer), createX);
 
         address factory = ICreateX(createX)

--- a/legacy/script/deploy/DeployDopplerERC20V1Factory.s.sol
+++ b/legacy/script/deploy/DeployDopplerERC20V1Factory.s.sol
@@ -1,0 +1,65 @@
+/// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { DopplerERC20V1Factory } from "src/tokens/DopplerERC20V1Factory.sol";
+
+error UnexpectedAddress();
+
+contract DeployDopplerERC20V1FactoryScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.MONAD_MAINNET;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address airlock = config.get("airlock").toAddress();
+        address createX = config.get("create_x").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(DopplerERC20V1Factory).name);
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address dopplerERC20V1Factory = ICreateX(createX)
+            .deployCreate3(salt, abi.encodePacked(type(DopplerERC20V1Factory).creationCode, abi.encode(airlock)));
+        require(dopplerERC20V1Factory == expectedAddress, UnexpectedAddress());
+        vm.stopBroadcast();
+
+        address implementation = DopplerERC20V1Factory(dopplerERC20V1Factory).IMPLEMENTATION();
+
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            config.set("doppler_erc20_v1_factory", dopplerERC20V1Factory);
+            config.set("doppler_erc20_v1_implementation", implementation);
+        }
+        console.log(
+            "DopplerERC20V1Factory was deployed to",
+            LibString.toHexString(uint256(uint160(dopplerERC20V1Factory))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+        console.log(
+            "DopplerERC20V1 implementation was deployed to",
+            LibString.toHexString(uint256(uint160(implementation))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}

--- a/legacy/script/deploy/DeployDopplerHookInitializer.s.sol
+++ b/legacy/script/deploy/DeployDopplerHookInitializer.s.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { DopplerHookInitializer } from "src/initializers/DopplerHookInitializer.sol";
+import { MineDopplerHookInitializerParams, mineDopplerHookInitializer } from "test/shared/AirlockMiner.sol";
+
+contract DeployDopplerHookInitializerScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.MONAD_MAINNET;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address airlock = config.get("airlock").toAddress();
+        address createX = config.get("create_x").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+
+        vm.startBroadcast();
+        (bytes32 salt, address deployedTo) =
+            mineDopplerHookInitializer(MineDopplerHookInitializerParams({ sender: msg.sender, deployer: createX }));
+        address dopplerHookInitializer = ICreateX(createX)
+            .deployCreate3(
+                salt, abi.encodePacked(type(DopplerHookInitializer).creationCode, abi.encode(airlock, poolManager))
+            );
+        require(dopplerHookInitializer == deployedTo, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            config.set("doppler_hook_initializer", dopplerHookInitializer);
+        }
+        console.log(
+            "DopplerHookInitializer was deployed to",
+            LibString.toHexString(uint256(uint160(dopplerHookInitializer))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}

--- a/legacy/script/deploy/DeployDopplerHookMigrator.s.sol
+++ b/legacy/script/deploy/DeployDopplerHookMigrator.s.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { StreamableFeesLockerV2 } from "src/lockers/StreamableFeesLockerV2.sol";
+import { DopplerHookMigrator } from "src/migrators/DopplerHookMigrator.sol";
+import { MineDopplerHookMigratorParams, mineDopplerHookMigrator } from "test/shared/AirlockMiner.sol";
+
+contract DeployDopplerHookMigratorScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](5);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+        targets[4] = ChainIds.MONAD_MAINNET;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address airlock = config.get("airlock").toAddress();
+        address createX = config.get("create_x").toAddress();
+        address multiSig = config.get("airlock_multisig").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+        address topUpDistributor = config.get("top_up_distributor").toAddress();
+        address locker = config.get("streamable_fees_locker_v2").toAddress();
+
+        vm.startBroadcast();
+
+        (bytes32 migratorSalt, address migratorDeployedTo) =
+            mineDopplerHookMigrator(MineDopplerHookMigratorParams({ sender: msg.sender, deployer: createX }));
+        address dopplerHookMigrator = ICreateX(createX)
+            .deployCreate3(
+                migratorSalt,
+                abi.encodePacked(
+                    type(DopplerHookMigrator).creationCode, abi.encode(airlock, poolManager, locker, topUpDistributor)
+                )
+            );
+        require(dopplerHookMigrator == migratorDeployedTo, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("doppler_hook_migrator", dopplerHookMigrator);
+    }
+}

--- a/legacy/script/deploy/DeployDopplerLensQuoter.s.sol
+++ b/legacy/script/deploy/DeployDopplerLensQuoter.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { TypeKind, Variable } from "forge-std/LibVariable.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { DopplerLensQuoter } from "src/lens/DopplerLens.sol";
+
+contract DeployDopplerLensQuoterScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.MONAD_MAINNET;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address createX = config.get("create_x").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+        address stateView = config.get("uniswap_v4_state_view").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(DopplerLensQuoter).name);
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address dopplerLensQuoter = ICreateX(createX)
+            .deployCreate3(
+                salt, abi.encodePacked(type(DopplerLensQuoter).creationCode, abi.encode(poolManager, stateView))
+            );
+        require(dopplerLensQuoter == expectedAddress, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        // Only set the config if a broadcast has occurred
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) config.set("doppler_lens_quoter", dopplerLensQuoter);
+        console.log(
+            "DopplerLensQuoter was deployed to",
+            LibString.toHexString(uint256(uint160(dopplerLensQuoter))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}

--- a/legacy/script/deploy/DeployGovernanceFactory.s.sol
+++ b/legacy/script/deploy/DeployGovernanceFactory.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { GovernanceFactory } from "src/governance/GovernanceFactory.sol";
+
+contract DeployGovernanceFactoryScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](2);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address createX = config.get("create_x").toAddress();
+        address airlock = config.get("airlock").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(GovernanceFactory).name);
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address governanceFactory = ICreateX(createX)
+            .deployCreate3(salt, abi.encodePacked(type(GovernanceFactory).creationCode, abi.encode(airlock)));
+        require(governanceFactory == expectedAddress, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("governance_factory", governanceFactory);
+    }
+}

--- a/legacy/script/deploy/DeployLaunchpadGovernanceFactory.s.sol
+++ b/legacy/script/deploy/DeployLaunchpadGovernanceFactory.s.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { LaunchpadGovernanceFactory } from "src/governance/LaunchpadGovernanceFactory.sol";
+
+struct ScriptData {
+    uint256 chainId;
+}
+
+abstract contract DeployLaunchpadGovernanceFactoryScript is Script {
+    ScriptData internal _scriptData;
+
+    function setUp() public virtual;
+
+    function run() public {
+        vm.startBroadcast();
+        require(block.chainid == _scriptData.chainId, "Invalid chainId");
+        new LaunchpadGovernanceFactory();
+        vm.stopBroadcast();
+    }
+}
+
+/// @dev forge script DeployLaunchpadGovernanceFactoryEthereumMainnetScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $ETH_MAINNET_RPC_URL
+contract DeployLaunchpadGovernanceFactoryEthereumMainnetScript is DeployLaunchpadGovernanceFactoryScript {
+    function setUp() public override {
+        _scriptData = ScriptData({ chainId: ChainIds.ETH_MAINNET });
+    }
+}
+
+/// @dev forge script DeployLaunchpadGovernanceFactoryBaseScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $BASE_MAINNET_RPC_URL
+contract DeployLaunchpadGovernanceFactoryBaseScript is DeployLaunchpadGovernanceFactoryScript {
+    function setUp() public override {
+        _scriptData = ScriptData({ chainId: ChainIds.BASE_MAINNET });
+    }
+}
+
+/// @dev forge script DeployLaunchpadGovernanceFactoryBaseSepoliaScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $BASE_SEPOLIA_RPC_URL
+contract DeployLaunchpadGovernanceFactoryBaseSepoliaScript is DeployLaunchpadGovernanceFactoryScript {
+    function setUp() public override {
+        _scriptData = ScriptData({ chainId: ChainIds.BASE_SEPOLIA });
+    }
+}
+
+/// @dev forge script DeployLaunchpadGovernanceFactoryMonadTestnetScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $MONAD_TESTNET_RPC_URL
+contract DeployLaunchpadGovernanceFactoryMonadTestnetScript is DeployLaunchpadGovernanceFactoryScript {
+    function setUp() public override {
+        _scriptData = ScriptData({ chainId: ChainIds.MONAD_TESTNET });
+    }
+}

--- a/legacy/script/deploy/DeployLockableUniswapV3Initializer.s.sol
+++ b/legacy/script/deploy/DeployLockableUniswapV3Initializer.s.sol
@@ -1,0 +1,120 @@
+/// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { IUniswapV3Factory } from "@v3-core/interfaces/IUniswapV3Factory.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { LockableUniswapV3Initializer } from "src/initializers/LockableUniswapV3Initializer.sol";
+
+struct ScriptData {
+    address airlock;
+    address uniswapV3Factory;
+    uint256 chainId;
+}
+
+abstract contract DeployLockableUniswapV3InitializerScript is Script, Config {
+    ScriptData internal _scriptData;
+
+    function setUp() public virtual {
+        _loadConfigAndForks("./deployments.config.toml", true);
+    }
+
+    function run() public {
+        vm.startBroadcast();
+        LockableUniswapV3Initializer initializer =
+            new LockableUniswapV3Initializer(_scriptData.airlock, IUniswapV3Factory(_scriptData.uniswapV3Factory));
+        vm.stopBroadcast();
+
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            config.set("lockable_uniswap_v3_initializer", address(initializer));
+        }
+        console.log(
+            "LockableUniswapV3Initializer was deployed to",
+            LibString.toHexString(uint256(uint160(address(initializer)))),
+            "on chain ID",
+            LibString.toString(_scriptData.chainId)
+        );
+    }
+}
+
+/// @dev forge script DeployLockableUniswapV3InitializerEthereumMainnet --private-key $PRIVATE_KEY --verify --slow --broadcast
+contract DeployLockableUniswapV3InitializerEthereumMainnet is DeployLockableUniswapV3InitializerScript {
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(forkOf[ChainIds.ETH_MAINNET]);
+        _scriptData = ScriptData({
+            airlock: config.get("airlock").toAddress(),
+            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
+            chainId: ChainIds.ETH_MAINNET
+        });
+    }
+}
+
+/// @dev forge script DeployLockableUniswapV3InitializerBaseSepolia --private-key $PRIVATE_KEY --verify --slow --broadcast
+contract DeployLockableUniswapV3InitializerBaseSepolia is DeployLockableUniswapV3InitializerScript {
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(forkOf[ChainIds.BASE_SEPOLIA]);
+        _scriptData = ScriptData({
+            airlock: config.get("airlock").toAddress(),
+            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
+            chainId: ChainIds.BASE_SEPOLIA
+        });
+    }
+}
+
+/// @dev forge script DeployLockableUniswapV3InitializerBase --private-key $PRIVATE_KEY --verify --slow --broadcast
+contract DeployLockableUniswapV3InitializerBase is DeployLockableUniswapV3InitializerScript {
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(forkOf[ChainIds.BASE_MAINNET]);
+        _scriptData = ScriptData({
+            airlock: config.get("airlock").toAddress(),
+            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
+            chainId: ChainIds.BASE_MAINNET
+        });
+    }
+}
+
+/// @dev forge script DeployLockableUniswapV3InitializerUnichainSepolia --private-key $PRIVATE_KEY --verify --slow --broadcast
+contract DeployLockableUniswapV3InitializerUnichainSepolia is DeployLockableUniswapV3InitializerScript {
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(forkOf[ChainIds.UNICHAIN_SEPOLIA]);
+        _scriptData = ScriptData({
+            airlock: config.get("airlock").toAddress(),
+            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
+            chainId: ChainIds.UNICHAIN_SEPOLIA
+        });
+    }
+}
+
+/// @dev forge script DeployLockableUniswapV3InitializerUnichain --private-key $PRIVATE_KEY --verify --slow --broadcast
+contract DeployLockableUniswapV3InitializerUnichain is DeployLockableUniswapV3InitializerScript {
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(forkOf[ChainIds.UNICHAIN_MAINNET]);
+        _scriptData = ScriptData({
+            airlock: config.get("airlock").toAddress(),
+            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
+            chainId: ChainIds.UNICHAIN_MAINNET
+        });
+    }
+}
+
+/// @dev forge script DeployLockableUniswapV3InitializerMonad --private-key $PRIVATE_KEY --verify --slow --broadcast
+contract DeployLockableUniswapV3InitializerMonad is DeployLockableUniswapV3InitializerScript {
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(forkOf[ChainIds.MONAD_MAINNET]);
+        _scriptData = ScriptData({
+            airlock: config.get("airlock").toAddress(),
+            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
+            chainId: ChainIds.MONAD_MAINNET
+        });
+    }
+}

--- a/legacy/script/deploy/DeployNoOpGovernanceFactory.s.sol
+++ b/legacy/script/deploy/DeployNoOpGovernanceFactory.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt } from "script/utils/CreateX.sol";
+import { NoOpGovernanceFactory } from "src/governance/NoOpGovernanceFactory.sol";
+
+contract DeployNoOpGovernanceFactoryScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](2);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address createX = config.get("create_x").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = bytes32((uint256(uint160(msg.sender)) << 96) + uint256(0xdeadb055deadb055));
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address noOpGovernanceFactory =
+            ICreateX(createX).deployCreate3(salt, abi.encodePacked(type(NoOpGovernanceFactory).creationCode));
+        require(noOpGovernanceFactory == expectedAddress, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("no_op_governance_factory", noOpGovernanceFactory);
+    }
+}

--- a/legacy/script/deploy/DeployNoOpMigrator.s.sol
+++ b/legacy/script/deploy/DeployNoOpMigrator.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt } from "script/utils/CreateX.sol";
+import { NoOpMigrator } from "src/migrators/NoOpMigrator.sol";
+
+contract DeployNoOpMigratorScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](2);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address createX = config.get("create_x").toAddress();
+        address airlock = config.get("airlock").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = bytes32((uint256(uint160(msg.sender)) << 96) + uint256(0xdeaddeaddeaddead));
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address noOpMigrator = ICreateX(createX)
+            .deployCreate3(salt, abi.encodePacked(type(NoOpMigrator).creationCode, abi.encode(airlock)));
+        require(noOpMigrator == expectedAddress, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("no_op_migrator", noOpMigrator);
+    }
+}

--- a/legacy/script/deploy/DeployRehypeDopplerHookInitializer.s.sol
+++ b/legacy/script/deploy/DeployRehypeDopplerHookInitializer.s.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { RehypeDopplerHookInitializer } from "src/dopplerHooks/RehypeDopplerHookInitializer.sol";
+
+contract DeployRehypeDopplerHookInitializerScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.MONAD_MAINNET;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address createX = config.get("create_x").toAddress();
+        address dopplerHookInitializer = config.get("doppler_hook_initializer").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, "RehypeDopplerHookInitializer-6");
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), address(createX));
+
+        address rehypeDopplerHook = ICreateX(createX)
+            .deployCreate3(
+                salt,
+                abi.encodePacked(
+                    type(RehypeDopplerHookInitializer).creationCode, abi.encode(dopplerHookInitializer, poolManager)
+                )
+            );
+        require(rehypeDopplerHook == expectedAddress, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            config.set("rehype_doppler_hook_initializer", rehypeDopplerHook);
+            config.set("quoter", address(RehypeDopplerHookInitializer(payable(rehypeDopplerHook)).quoter()));
+        }
+        console.log(
+            "RehypeDopplerHookInitializer was deployed to",
+            LibString.toHexString(uint256(uint160(rehypeDopplerHook))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}

--- a/legacy/script/deploy/DeployRehypeDopplerHookMigrator.s.sol
+++ b/legacy/script/deploy/DeployRehypeDopplerHookMigrator.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { RehypeDopplerHookMigrator } from "src/dopplerHooks/RehypeDopplerHookMigrator.sol";
+
+contract DeployRehypeHookMigratorScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](1);
+        //targets[0] = ChainIds.ETH_MAINNET;
+        targets[0] = ChainIds.MONAD_MAINNET;
+        //targets[2] = ChainIds.BASE_MAINNET;
+        //targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address createX = config.get("create_x").toAddress();
+        address migrator = config.get("doppler_hook_migrator").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, "RehypeDopplerHookMigrator-5");
+        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), address(createX));
+
+        address rehypeDopplerHookMigrator = ICreateX(createX)
+            .deployCreate3(
+                salt, abi.encodePacked(type(RehypeDopplerHookMigrator).creationCode, abi.encode(migrator, poolManager))
+            );
+        require(rehypeDopplerHookMigrator == expectedAddress, "Unexpected deployed address");
+        vm.stopBroadcast();
+
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            config.set("rehype_doppler_hook_migrator", rehypeDopplerHookMigrator);
+            config.set("quoter", address(RehypeDopplerHookMigrator(payable(rehypeDopplerHookMigrator)).quoter()));
+        }
+        console.log(
+            "RehypeDopplerHookMigrator was deployed to",
+            LibString.toHexString(uint256(uint160(rehypeDopplerHookMigrator))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}

--- a/legacy/script/deploy/DeployStreamableFeesLockerV2.s.sol
+++ b/legacy/script/deploy/DeployStreamableFeesLockerV2.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { StreamableFeesLockerV2 } from "src/lockers/StreamableFeesLockerV2.sol";
+
+contract DeployStreamableFeesLockerV2Script is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.MONAD_MAINNET;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address createX = config.get("create_x").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+        address owner = config.get("airlock_multisig").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(StreamableFeesLockerV2).name);
+        address deployedTo = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address lockerV2 = ICreateX(createX)
+            .deployCreate3(
+                salt, abi.encodePacked(type(StreamableFeesLockerV2).creationCode, abi.encode(poolManager, owner))
+            );
+
+        require(lockerV2 == deployedTo, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("streamable_fees_locker_v2", lockerV2);
+    }
+}

--- a/legacy/script/deploy/DeployTopUpDistributor.s.sol
+++ b/legacy/script/deploy/DeployTopUpDistributor.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { TopUpDistributor } from "src/TopUpDistributor.sol";
+
+contract DeployTopUpDistributorScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](5);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+        targets[4] = ChainIds.MONAD_MAINNET;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address airlock = config.get("airlock").toAddress();
+        address createX = config.get("create_x").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, "TopUpDistributor-2");
+        address deployedTo = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address topUpDistributor = ICreateX(createX)
+            .deployCreate3(salt, abi.encodePacked(type(TopUpDistributor).creationCode, abi.encode(airlock)));
+
+        require(topUpDistributor == deployedTo, "Unexpected deployed address");
+
+        vm.stopBroadcast();
+        config.set("top_up_distributor", topUpDistributor);
+    }
+}

--- a/legacy/script/deploy/DeployUniV2MigratorSplit.s.sol
+++ b/legacy/script/deploy/DeployUniV2MigratorSplit.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { TypeKind, Variable } from "forge-std/LibVariable.sol";
+import { Script } from "forge-std/Script.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { LibString } from "solady/utils/LibString.sol";
+import { Airlock } from "src/Airlock.sol";
+import { UniswapV2MigratorSplit } from "src/migrators/UniswapV2MigratorSplit.sol";
+
+contract DeployUniV2MigratorSplitScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](4);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.MONAD_MAINNET;
+        targets[2] = ChainIds.BASE_MAINNET;
+        targets[3] = ChainIds.BASE_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            vm.selectFork(forkOf[chainId]);
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        address airlock = config.get("airlock").toAddress();
+        address createX = config.get("create_x").toAddress();
+        address uniswapV2Factory = config.get("uniswap_v2_factory").toAddress();
+        address topUpDistributor = config.get("top_up_distributor").toAddress();
+        address weth = config.get("weth").toAddress();
+
+        vm.startBroadcast();
+        bytes32 salt = generateCreate3Salt(msg.sender, type(UniswapV2MigratorSplit).name);
+        address deployedTo = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+
+        address migrator = ICreateX(createX)
+            .deployCreate3(
+                salt,
+                abi.encodePacked(
+                    type(UniswapV2MigratorSplit).creationCode,
+                    abi.encode(airlock, uniswapV2Factory, topUpDistributor, weth)
+                )
+            );
+        require(migrator == deployedTo, "Unexpected deployed address");
+        vm.stopBroadcast();
+        address locker = address(UniswapV2MigratorSplit(payable(migrator)).locker());
+
+        // Only set the config if a broadcast has occurred
+        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
+            config.set("uniswap_v2_migrator_split", migrator);
+            config.set("uniswap_v2_locker", locker);
+        }
+        console.log(
+            "UniswapV2MigratorSplit was deployed to",
+            LibString.toHexString(uint256(uint160(migrator))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+        console.log(
+            "UniswapV2Locker was deployed to",
+            LibString.toHexString(uint256(uint160(locker))),
+            "on chain ID",
+            LibString.toString(chainId)
+        );
+    }
+}

--- a/legacy/script/deploy/DeployUniswapV4Initializer.s.sol
+++ b/legacy/script/deploy/DeployUniswapV4Initializer.s.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { IPoolManager } from "@v4-core/interfaces/IPoolManager.sol";
+import { ICreateX } from "createx/ICreateX.sol";
+import { Config } from "forge-std/Config.sol";
+import { Script } from "forge-std/Script.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { DopplerDeployer, UniswapV4Initializer } from "src/initializers/UniswapV4Initializer.sol";
+
+contract DeployUniswapV4InitializerScript is Script, Config {
+    function run() public {
+        _loadConfigAndForks("./deployments.config.toml", true);
+
+        uint256[] memory targets = new uint256[](2);
+        targets[0] = ChainIds.ETH_MAINNET;
+        targets[1] = ChainIds.ETH_SEPOLIA;
+
+        for (uint256 i; i < targets.length; i++) {
+            uint256 chainId = targets[i];
+            deployToChain(chainId);
+        }
+    }
+
+    function deployToChain(uint256 chainId) internal {
+        vm.selectFork(forkOf[chainId]);
+
+        address airlock = config.get("airlock").toAddress();
+        address createX = config.get("create_x").toAddress();
+        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+
+        vm.startBroadcast();
+        bytes32 dopplerDeployerSalt = generateCreate3Salt(msg.sender, type(DopplerDeployer).name);
+        address expectedDoppledDeployer =
+            computeCreate3Address(computeCreate3GuardedSalt(dopplerDeployerSalt, msg.sender), createX);
+
+        address dopplerDeployer = ICreateX(createX)
+            .deployCreate3(
+                dopplerDeployerSalt, abi.encodePacked(type(DopplerDeployer).creationCode, abi.encode(poolManager))
+            );
+        require(dopplerDeployer == expectedDoppledDeployer, "Unexpected DopplerDeployer address");
+
+        bytes32 uniswapV4InitializerSalt = generateCreate3Salt(msg.sender, type(UniswapV4Initializer).name);
+        address expectedUniswapV4Initializer =
+            computeCreate3Address(computeCreate3GuardedSalt(uniswapV4InitializerSalt, msg.sender), createX);
+
+        address uniswapV4Initializer = ICreateX(createX)
+            .deployCreate3(
+                uniswapV4InitializerSalt,
+                abi.encodePacked(
+                    type(UniswapV4Initializer).creationCode, abi.encode(airlock, poolManager, dopplerDeployer)
+                )
+            );
+        require(uniswapV4Initializer == expectedUniswapV4Initializer, "Unexpected UniswapV4Initializer address");
+
+        vm.stopBroadcast();
+        config.set("uniswap_v4_initializer", uniswapV4Initializer);
+        config.set("doppler_deployer", dopplerDeployer);
+    }
+}

--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -12,8 +12,10 @@ import { DopplerCreateXDeployer } from "src/DopplerCreateXDeployer.sol";
 abstract contract DeployBase is Script, Config, Versions {
     ICreateX internal constant CREATE_X = ICreateX(0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed);
     string internal constant DEPLOYMENTS_CONFIG_PATH = "./deployments.config.toml";
+    string internal constant IS_TESTNET_KEY = "is_testnet";
     string internal constant PROTOCOL_DEPLOYER_KEY = "protocol_deployer";
 
+    error Create2AddressMismatch(bytes32 salt, address expected, address computed);
     error Create3AddressMismatch(bytes32 salt, address expected, address computed);
     error InvalidCreateXGuardedSalt(bytes32 salt);
     error BroadcastSenderMismatch(address expected, address actual);
@@ -40,9 +42,16 @@ abstract contract DeployBase is Script, Config, Versions {
         require(block.chainid == chainId, "Selected fork has unexpected chainId");
     }
 
+    /// @notice Loads shared config, selects `chainId`, and checks its configured testnet flag.
+    /// @dev Chain-specific script wrappers use this to keep baked-in chain targets honest.
+    function _loadConfigAndSelectFork(uint256 chainId, bool expectedIsTestnet) internal {
+        _loadConfigAndSelectFork(chainId);
+        require(_isConfiguredTestnet(chainId) == expectedIsTestnet, "DeployBase testnet flag mismatch");
+    }
+
     /// @notice Builds the common deployment context for scripts that deploy through the protocol deployer.
     /// @dev Resolves chain config, the protocol deployer address, broadcaster, and whether config writes are enabled.
-    function _deployContext() internal view returns (DeployContext memory context) {
+    function _deployContext() internal returns (DeployContext memory context) {
         uint256 chainId = block.chainid;
         require(config.exists(chainId, PROTOCOL_DEPLOYER_KEY), "protocol_deployer is not configured");
 
@@ -50,7 +59,7 @@ abstract contract DeployBase is Script, Config, Versions {
             chainId: chainId,
             config: config,
             protocolDeployer: DopplerCreateXDeployer(config.get(chainId, PROTOCOL_DEPLOYER_KEY).toAddress()),
-            broadcaster: msg.sender,
+            broadcaster: _resolveBroadcastSender(),
             writeConfig: _shouldWriteConfig()
         });
     }
@@ -59,6 +68,12 @@ abstract contract DeployBase is Script, Config, Versions {
     /// @dev Config writes are limited to broadcast runs so simulations and dry runs do not mutate local config.
     function _shouldWriteConfig() internal view returns (bool) {
         return vm.isContext(VmSafe.ForgeContext.ScriptBroadcast);
+    }
+
+    /// @notice Returns the configured testnet flag for `chainId`.
+    function _isConfiguredTestnet(uint256 chainId) internal view returns (bool) {
+        require(config.exists(chainId, IS_TESTNET_KEY), "is_testnet is not configured");
+        return config.get(chainId, IS_TESTNET_KEY).toBool();
     }
 
     /// @notice Writes a chain-scoped address into the shared deployments config when writes are enabled.
@@ -101,17 +116,38 @@ abstract contract DeployBase is Script, Config, Versions {
         return (deployed, false);
     }
 
-    /// @notice Deploys a bootstrap contract directly through CreateX or returns existing code at `expected`.
+    /// @notice Deploys a versioned contract through the protocol deployer.
+    /// @dev `customSalt` and `customExpected` are optional, but must be provided together when either is set.
+    function _deployOrUseExistingVersionedCreate3(
+        DeployContext memory context,
+        bytes32 customSalt,
+        address customExpected,
+        string memory contractName,
+        uint8 version,
+        bytes memory initCode
+    ) internal returns (address deployed, bool alreadyDeployed) {
+        _requireCompleteDeploymentConfig(customSalt, customExpected);
+
+        bytes32 deploymentSalt =
+            customSalt != bytes32(0) ? customSalt : context.protocolDeployer.generateSalt(contractName, version);
+        address expected = customExpected != address(0)
+            ? customExpected
+            : _computeProtocolCreate3Address(context.protocolDeployer, deploymentSalt);
+
+        return _deployOrUseExistingCreate3(context, deploymentSalt, expected, initCode);
+    }
+
+    /// @notice Deploys a bootstrap contract directly through CreateX CREATE2 or returns existing code at `expected`.
     /// @dev Used for contracts needed before the protocol deployer exists and mirrors CreateX guarded salt handling.
     ///      Callers are responsible for validating and recording the deployment.
-    function _deployOrUseExistingCreateXCreate3(
+    function _deployOrUseExistingCreateXCreate2(
         bytes32 deploymentSalt,
         address expected,
         bytes memory initCode
     ) internal returns (address deployed, bool alreadyDeployed) {
         address broadcaster = _resolveBroadcastSender();
-        address computed = _computeCreateXCreate3Address(deploymentSalt, broadcaster);
-        _verifyCreate3Address(deploymentSalt, expected, computed);
+        address computed = _computeCreateXCreate2Address(deploymentSalt, broadcaster, keccak256(initCode));
+        _verifyCreate2Address(deploymentSalt, expected, computed);
 
         if (expected.code.length != 0) {
             return (expected, true);
@@ -119,11 +155,18 @@ abstract contract DeployBase is Script, Config, Versions {
 
         vm.startBroadcast();
         _verifyBroadcastSender(broadcaster);
-        deployed = CREATE_X.deployCreate3(deploymentSalt, initCode);
+        deployed = CREATE_X.deployCreate2(deploymentSalt, initCode);
         vm.stopBroadcast();
 
-        _verifyCreate3Address(deploymentSalt, expected, deployed);
+        _verifyCreate2Address(deploymentSalt, expected, deployed);
         return (deployed, false);
+    }
+
+    /// @notice Reverts unless a computed or deployed CREATE2 address matches the expected address.
+    function _verifyCreate2Address(bytes32 deploymentSalt, address expected, address computed) internal pure {
+        if (computed != expected) {
+            revert Create2AddressMismatch(deploymentSalt, expected, computed);
+        }
     }
 
     /// @notice Reverts unless a computed or deployed CREATE3 address matches the expected address.
@@ -132,6 +175,11 @@ abstract contract DeployBase is Script, Config, Versions {
         if (computed != expected) {
             revert Create3AddressMismatch(deploymentSalt, expected, computed);
         }
+    }
+
+    /// @notice Reverts unless optional custom salt and expected-address overrides are complete.
+    function _requireCompleteDeploymentConfig(bytes32 deploymentSalt, address expected) internal pure {
+        require((deploymentSalt == bytes32(0)) == (expected == address(0)), "Deployment configuration is incomplete");
     }
 
     /// @notice Computes the CREATE3 address for a deployment sent through the protocol deployer.
@@ -144,10 +192,14 @@ abstract contract DeployBase is Script, Config, Versions {
         return CREATE_X.computeCreate3Address(guardedSalt);
     }
 
-    /// @notice Computes the direct CreateX CREATE3 address for `deploymentSalt` and `caller`.
+    /// @notice Computes the direct CreateX CREATE2 address for `deploymentSalt`, `caller`, and `initCodeHash`.
     /// @dev Used by bootstrap scripts that call CreateX directly instead of routing through the protocol deployer.
-    function _computeCreateXCreate3Address(bytes32 deploymentSalt, address caller) internal view returns (address) {
-        return CREATE_X.computeCreate3Address(_computeCreateXGuardedSalt(deploymentSalt, caller));
+    function _computeCreateXCreate2Address(
+        bytes32 deploymentSalt,
+        address caller,
+        bytes32 initCodeHash
+    ) internal view returns (address) {
+        return CREATE_X.computeCreate2Address(_computeCreateXGuardedSalt(deploymentSalt, caller), initCodeHash);
     }
 
     /// @notice Resolves the sender Foundry will use for default `vm.startBroadcast()` calls.

--- a/script/DeployDoppler.s.sol
+++ b/script/DeployDoppler.s.sol
@@ -2,40 +2,130 @@
 pragma solidity ^0.8.24;
 
 import { DeployAirlock } from "script/deploy/DeployAirlock.s.sol";
+import { DeployAirlockMultisigTestnet } from "script/deploy/DeployAirlockMultisigTestnet.s.sol";
+import { DeployBundler } from "script/deploy/DeployBundler.s.sol";
+import { DeployDN404Factory } from "script/deploy/DeployDN404Factory.s.sol";
+import { DeployDopplerERC20V1Factory } from "script/deploy/DeployDopplerERC20V1Factory.s.sol";
+import { DeployDopplerHookInitializer } from "script/deploy/DeployDopplerHookInitializer.s.sol";
+import { DeployDopplerHookMigrator } from "script/deploy/DeployDopplerHookMigrator.s.sol";
+import { DeployDopplerLensQuoter } from "script/deploy/DeployDopplerLensQuoter.s.sol";
+import { DeployGovernanceFactory } from "script/deploy/DeployGovernanceFactory.s.sol";
+import { DeployLaunchpadGovernanceFactory } from "script/deploy/DeployLaunchpadGovernanceFactory.s.sol";
+import { DeployLockableUniswapV3Initializer } from "script/deploy/DeployLockableUniswapV3Initializer.s.sol";
+import { DeployNoOpGovernanceFactory } from "script/deploy/DeployNoOpGovernanceFactory.s.sol";
+import { DeployNoOpMigrator } from "script/deploy/DeployNoOpMigrator.s.sol";
+import { DeployRehypeDopplerHookInitializer } from "script/deploy/DeployRehypeDopplerHookInitializer.s.sol";
+import { DeployRehypeDopplerHookMigrator } from "script/deploy/DeployRehypeDopplerHookMigrator.s.sol";
+import { DeployStreamableFeesLockerV2 } from "script/deploy/DeployStreamableFeesLockerV2.s.sol";
+import { DeploySwapRestrictorDopplerHook } from "script/deploy/DeploySwapRestrictorDopplerHook.s.sol";
+import { DeployTopUpDistributor } from "script/deploy/DeployTopUpDistributor.s.sol";
+import { DeployUniV2MigratorSplit } from "script/deploy/DeployUniV2MigratorSplit.s.sol";
+import { DeployUniswapV4Initializer } from "script/deploy/DeployUniswapV4Initializer.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
 
-contract DeployDopplerScript is DeployAirlock {
+contract DeployDopplerScript is
+    DeployAirlock,
+    DeployAirlockMultisigTestnet,
+    DeployTopUpDistributor,
+    DeployStreamableFeesLockerV2,
+    DeployDopplerERC20V1Factory,
+    DeployDN404Factory,
+    DeployNoOpGovernanceFactory,
+    DeployGovernanceFactory,
+    DeployLaunchpadGovernanceFactory,
+    DeployLockableUniswapV3Initializer,
+    DeployUniswapV4Initializer,
+    DeployDopplerHookInitializer,
+    DeployRehypeDopplerHookInitializer,
+    DeploySwapRestrictorDopplerHook,
+    DeployNoOpMigrator,
+    DeployUniV2MigratorSplit,
+    DeployDopplerHookMigrator,
+    DeployRehypeDopplerHookMigrator,
+    DeployDopplerLensQuoter,
+    DeployBundler
+{
+    bool internal isTestnet;
+
+    struct DeployedAddresses {
+        address airlockMultisig;
+        address airlock;
+        address topUpDistributor;
+        address streamableFeesLockerV2;
+        address dopplerHookInitializer;
+        address dopplerHookMigrator;
+    }
+
     function setUp() public virtual {
         _loadConfigForCurrentChain();
+        isTestnet = _isConfiguredTestnet(block.chainid);
     }
 
     function run() public {
-        _deployAirlock(_deployContext());
-        // TODO: Revise remaining deployment scripts to follow the patterns established in DeployDeployerScript and DeployAirlockScript
-        // Then update this script to call each of the remaining deployment scripts for all contracts specified in Versions.sol
+        DeployContext memory context = _deployContext();
+        DeployedAddresses memory deployed;
+
+        if (isTestnet) {
+            deployed.airlockMultisig = _deployAirlockMultisigTestnet(context);
+        } else {
+            deployed.airlockMultisig = context.config.get(context.chainId, "airlock_multisig").toAddress();
+        }
+
+        deployed.airlock = _deployAirlock(context, deployed.airlockMultisig);
+        deployed.topUpDistributor = _deployTopUpDistributor(context, deployed.airlock);
+        deployed.streamableFeesLockerV2 = _deployStreamableFeesLockerV2(context, deployed.airlockMultisig);
+
+        _deployDopplerERC20V1Factory(context, deployed.airlock);
+        _deployDN404Factory(context, deployed.airlock);
+
+        _deployNoOpGovernanceFactory(context);
+        _deployGovernanceFactory(context, deployed.airlock);
+        _deployLaunchpadGovernanceFactory(context);
+
+        _deployLockableUniswapV3Initializer(context, deployed.airlock);
+        _deployUniswapV4Initializer(context, deployed.airlock);
+        deployed.dopplerHookInitializer = _deployDopplerHookInitializer(context, deployed.airlock);
+
+        _deployRehypeDopplerHookInitializer(context, deployed.dopplerHookInitializer);
+        _deploySwapRestrictorDopplerHook(context, deployed.dopplerHookInitializer);
+
+        _deployNoOpMigrator(context, deployed.airlock);
+        _deployUniV2MigratorSplit(context, deployed.airlock, deployed.topUpDistributor);
+        deployed.dopplerHookMigrator = _deployDopplerHookMigrator(
+            context, deployed.airlock, deployed.topUpDistributor, deployed.streamableFeesLockerV2
+        );
+        _deployRehypeDopplerHookMigrator(context, deployed.dopplerHookMigrator);
+
+        _deployDopplerLensQuoter(context);
+        _deployBundler(context, deployed.airlock);
+    }
+
+    function _setUpChain(uint256 chainId, bool _isTestnet) internal {
+        _loadConfigAndSelectFork(chainId, _isTestnet);
+        isTestnet = _isTestnet;
     }
 }
 
 contract DeployDopplerScriptEthereum is DeployDopplerScript {
     function setUp() public override {
-        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET);
+        _setUpChain(ChainIds.ETH_MAINNET, false);
     }
 }
 
 contract DeployDopplerScriptMonad is DeployDopplerScript {
     function setUp() public override {
-        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET);
+        _setUpChain(ChainIds.MONAD_MAINNET, false);
     }
 }
 
 contract DeployDopplerScriptBase is DeployDopplerScript {
     function setUp() public override {
-        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET);
+        _setUpChain(ChainIds.BASE_MAINNET, false);
     }
 }
 
 contract DeployDopplerScriptBaseSepolia is DeployDopplerScript {
     function setUp() public override {
-        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA);
+        _setUpChain(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/DeployDopplerCreateXDeployer.s.sol
+++ b/script/DeployDopplerCreateXDeployer.s.sol
@@ -20,7 +20,7 @@ contract DeployDopplerCreateXDeployerScript is DeployBase {
         address deployerOwner = config.get("deployer_owner").toAddress();
         bytes memory initCode = abi.encodePacked(type(DopplerCreateXDeployer).creationCode, abi.encode(deployerOwner));
 
-        (address deployer, bool alreadyDeployed) = _deployOrUseExistingCreateXCreate3(salt, expectedAddress, initCode);
+        (address deployer, bool alreadyDeployed) = _deployOrUseExistingCreateXCreate2(salt, expectedAddress, initCode);
 
         _verifyExistingDeployment(deployer, deployerOwner);
         _setConfigAddress(PROTOCOL_DEPLOYER_KEY, deployer);

--- a/script/deploy/DeployAirlock.s.sol
+++ b/script/deploy/DeployAirlock.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import { console } from "forge-std/console.sol";
 import { DeployBase } from "script/DeployBase.s.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
 import { Airlock } from "src/Airlock.sol";
 
 abstract contract DeployAirlock is DeployBase {
@@ -10,20 +11,17 @@ abstract contract DeployAirlock is DeployBase {
     address public expectedAddress; // Only set if you've configured a custom salt
 
     function _deployAirlock(DeployContext memory context) internal returns (address airlock) {
-        if (salt != bytes32(0) || expectedAddress != address(0)) {
-            require(salt != bytes32(0) && expectedAddress != address(0), "Deployment configuration is incomplete");
-        }
-
         address multisig = context.config.get(context.chainId, "airlock_multisig").toAddress();
+        return _deployAirlock(context, multisig);
+    }
 
-        bytes32 deploymentSalt =
-            salt != bytes32(0) ? salt : context.protocolDeployer.generateSalt(type(Airlock).name, AIRLOCK_VERSION);
-        address computedExpected = _computeProtocolCreate3Address(context.protocolDeployer, deploymentSalt);
-        address deploymentExpected = expectedAddress != address(0) ? expectedAddress : computedExpected;
+    function _deployAirlock(DeployContext memory context, address multisig) internal returns (address airlock) {
         bytes memory initCode = abi.encodePacked(type(Airlock).creationCode, abi.encode(multisig));
 
         bool alreadyDeployed;
-        (airlock, alreadyDeployed) = _deployOrUseExistingCreate3(context, deploymentSalt, deploymentExpected, initCode);
+        (airlock, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, salt, expectedAddress, type(Airlock).name, AIRLOCK_VERSION, initCode
+        );
 
         _verifyExistingDeployment(airlock, multisig);
         _setConfigAddress(context, "airlock", airlock);
@@ -60,5 +58,29 @@ contract DeployAirlockScript is DeployAirlock {
 
     function deploy() public returns (address airlock) {
         return _deployAirlock(_deployContext());
+    }
+}
+
+contract DeployAirlockScriptEthereum is DeployAirlockScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployAirlockScriptMonad is DeployAirlockScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployAirlockScriptBase is DeployAirlockScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployAirlockScriptBaseSepolia is DeployAirlockScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployAirlockMultisigTestnet.s.sol
+++ b/script/deploy/DeployAirlockMultisigTestnet.s.sol
@@ -1,53 +1,85 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { AirlockMultisigTestnet } from "script/utils/AirlockMultisigTestnet.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeGuardedSalt } from "test/shared/AirlockMiner.sol";
 
-contract DeployAirlockMultisigTestnetScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployAirlockMultisigTestnet is DeployBase {
+    bytes32 public airlockMultisigSalt; // Only set if you want to use a specific salt
+    address public airlockMultisigExpectedAddress; // Only set if you've configured a custom salt
 
-        uint256[] memory targets = new uint256[](1);
-        targets[0] = ChainIds.ETH_SEPOLIA;
+    function _deployAirlockMultisigTestnet(DeployContext memory context)
+        internal
+        returns (address airlockMultisigTestnet)
+    {
+        address[] memory signers = _airlockMultisigTestnetSigners();
+        bytes memory initCode = abi.encodePacked(type(AirlockMultisigTestnet).creationCode, abi.encode(signers));
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToTestnetChain(chainId);
+        bool alreadyDeployed;
+        (airlockMultisigTestnet, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            airlockMultisigSalt,
+            airlockMultisigExpectedAddress,
+            type(AirlockMultisigTestnet).name,
+            AIRLOCK_MULTISIG_VERSION,
+            initCode
+        );
+
+        _verifyAirlockMultisigTestnetDeployment(airlockMultisigTestnet, signers);
+        _setConfigAddress(context, "airlock_multisig", airlockMultisigTestnet);
+
+        if (alreadyDeployed) {
+            console.log("AirlockMultisigTestnet already deployed to:", airlockMultisigTestnet);
+        } else {
+            console.log("AirlockMultisigTestnet deployed to:", airlockMultisigTestnet);
         }
     }
 
-    function deployToTestnetChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
-
-        // We only deploy this multisig on testnets
-        if (config.get("is_testnet").toBool() == false) {
-            return;
-        }
-
-        address createX = config.get("create_x").toAddress();
-
-        vm.startBroadcast();
-
-        bytes32 salt = bytes32(uint256(uint160(msg.sender)) << 96 | 0xdeadbeef);
-        address expectedAddress = computeCreate3Address(computeGuardedSalt(salt, msg.sender), address(createX));
-
-        address[] memory signers = new address[](5);
-        signers[0] = msg.sender;
+    // TODO: Clean this up, verify all signers are current and valid
+    function _airlockMultisigTestnetSigners() internal pure returns (address[] memory signers) {
+        signers = new address[](8);
+        signers[0] = 0xaCE07c3c1D3b556D42633211f0Da71dc6F6d1c42;
         signers[1] = 0x88C23B886580FfAd04C66055edB6c777f5F74a08;
         signers[2] = 0x00D1C1c523D0058359850F8A1E49504ef78541cE;
         signers[3] = 0xdF95Cc445469816234Ad95f702c79d25BCE401a7;
         signers[4] = 0xD877ca966bA431102B6aB217A899fa686D7Fa639;
+        signers[5] = 0x38013363908d329749e5a47B391DB5f85A1eE969;
+        signers[6] = 0x97a90100d77D05E309cdeB7e2AaF91F0EF8CA5ac;
+        signers[7] = 0xF7608C49Fd0B21BD8bd1B24BBa456061ABa0F427;
+    }
 
-        address airlockMultisigTestnet = ICreateX(createX)
-            .deployCreate3(salt, abi.encodePacked(type(AirlockMultisigTestnet).creationCode, abi.encode(signers)));
-        require(airlockMultisigTestnet == expectedAddress, "Unexpected deployed address");
-        vm.stopBroadcast();
+    function _verifyAirlockMultisigTestnetDeployment(address addr, address[] memory signers) internal view {
+        AirlockMultisigTestnet multisig = AirlockMultisigTestnet(addr);
+        for (uint256 i; i < signers.length; i++) {
+            require(multisig.isSigner(signers[i]), "AirlockMultisigTestnet signer mismatch");
+        }
+    }
+}
 
-        config.set("airlock_multisig", airlockMultisigTestnet);
+contract DeployAirlockMultisigTestnetScript is DeployAirlockMultisigTestnet {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        if (!_isConfiguredTestnet(block.chainid)) {
+            console.log("Skipping AirlockMultisigTestnet deployment for non-testnet chain:", block.chainid);
+            return;
+        }
+
+        deploy();
+    }
+
+    function deploy() public returns (address airlockMultisigTestnet) {
+        require(_isConfiguredTestnet(block.chainid), "AirlockMultisigTestnet only deploys on testnets");
+        return _deployAirlockMultisigTestnet(_deployContext());
+    }
+}
+
+contract DeployAirlockMultisigTestnetScriptBaseSepolia is DeployAirlockMultisigTestnetScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployBundler.s.sol
+++ b/script/deploy/DeployBundler.s.sol
@@ -1,48 +1,88 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { Airlock } from "src/Airlock.sol";
 import { Bundler } from "src/Bundler.sol";
 
-contract DeployBundlerScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployBundler is DeployBase {
+    function _deployBundler(DeployContext memory context) internal returns (address bundler) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployBundler(context, airlock);
+    }
 
-        uint256[] memory targets = new uint256[](2);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
+    function _deployBundler(DeployContext memory context, address airlock) internal returns (address bundler) {
+        address quoterV2 = context.config.get(context.chainId, "quoter_v2").toAddress();
+        address quoterV4 = context.config.get(context.chainId, "quoter_v4").toAddress();
+        address router = context.config.get(context.chainId, "universal_router").toAddress();
+        bytes memory initCode =
+            abi.encodePacked(type(Bundler).creationCode, abi.encode(airlock, router, quoterV2, quoterV4));
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        bool alreadyDeployed;
+        (bundler, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(Bundler).name, BUNDLER_VERSION, initCode
+        );
+
+        _verifyBundlerDeployment(bundler, airlock, router, quoterV2, quoterV4);
+        _setConfigAddress(context, "bundler", bundler);
+
+        if (alreadyDeployed) {
+            console.log("Bundler already deployed to:", bundler);
+        } else {
+            console.log("Bundler deployed to:", bundler);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _verifyBundlerDeployment(
+        address addr,
+        address airlock,
+        address router,
+        address quoterV2,
+        address quoterV4
+    ) internal view {
+        Bundler bundler = Bundler(addr);
+        require(address(bundler.airlock()) == airlock, "Bundler airlock mismatch");
+        require(address(bundler.router()) == router, "Bundler router mismatch");
+        require(address(bundler.quoter()) == quoterV2, "Bundler quoter mismatch");
+        require(address(bundler.v4Quoter()) == quoterV4, "Bundler v4 quoter mismatch");
+    }
+}
 
-        address airlock = config.get("airlock").toAddress();
-        address quoterV2 = config.get("quoter_v2").toAddress();
-        address quoterV4 = config.get("quoter_v4").toAddress();
-        address router = config.get("universal_router").toAddress();
-        address createX = config.get("create_x").toAddress();
+contract DeployBundlerScript is DeployBundler {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, type(Bundler).name);
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+    function run() public virtual {
+        deploy();
+    }
 
-        address bundler = ICreateX(createX)
-            .deployCreate3(
-                salt, abi.encodePacked(type(Bundler).creationCode, abi.encode(airlock, router, quoterV2, quoterV4))
-            );
-        require(bundler == expectedAddress, "Unexpected deployed address");
+    function deploy() public returns (address bundler) {
+        return _deployBundler(_deployContext());
+    }
+}
 
-        vm.stopBroadcast();
-        config.set("bundler", bundler);
+contract DeployBundlerScriptEthereum is DeployBundlerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployBundlerScriptMonad is DeployBundlerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployBundlerScriptBase is DeployBundlerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployBundlerScriptBaseSepolia is DeployBundlerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployDN404Factory.s.sol
+++ b/script/deploy/DeployDN404Factory.s.sol
@@ -1,31 +1,74 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { ChainIds, checkChainId } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
 import { DN404Factory } from "src/tokens/DN404Factory.sol";
 
-contract DeployDN404FactoryBaseSepoliaScript is Script, Config {
-    function run() public {
-        checkChainId(ChainIds.BASE_SEPOLIA);
-        _loadConfig("./deployments.config.toml", true);
+abstract contract DeployDN404Factory is DeployBase {
+    function _deployDN404Factory(DeployContext memory context) internal returns (address factory) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployDN404Factory(context, airlock);
+    }
 
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
+    function _deployDN404Factory(DeployContext memory context, address airlock) internal returns (address factory) {
+        bytes memory initCode = abi.encodePacked(type(DN404Factory).creationCode, abi.encode(airlock));
 
-        vm.startBroadcast();
-        address deployer = tx.origin;
-        bytes32 salt = generateCreate3Salt(deployer, type(DN404Factory).name);
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, deployer), createX);
+        bool alreadyDeployed;
+        (factory, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(DN404Factory).name, DOPPLER_DN404_FACTORY_VERSION, initCode
+        );
 
-        address factory = ICreateX(createX)
-            .deployCreate3(salt, abi.encodePacked(type(DN404Factory).creationCode, abi.encode(airlock)));
-        require(factory == expectedAddress, "Unexpected deployed address");
+        _verifyDN404FactoryDeployment(factory, airlock);
+        _setConfigAddress(context, "dn404_factory", factory);
 
-        vm.stopBroadcast();
-        config.set("dn404_factory", factory);
+        if (alreadyDeployed) {
+            console.log("DN404Factory already deployed to:", factory);
+        } else {
+            console.log("DN404Factory deployed to:", factory);
+        }
+    }
+
+    function _verifyDN404FactoryDeployment(address addr, address airlock) internal view {
+        require(address(DN404Factory(addr).airlock()) == airlock, "DN404Factory airlock mismatch");
+    }
+}
+
+contract DeployDN404FactoryScript is DeployDN404Factory {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address factory) {
+        return _deployDN404Factory(_deployContext());
+    }
+}
+
+contract DeployDN404FactoryScriptEthereum is DeployDN404FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployDN404FactoryScriptMonad is DeployDN404FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployDN404FactoryScriptBase is DeployDN404FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployDN404FactoryScriptBaseSepolia is DeployDN404FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployDopplerERC20V1Factory.s.sol
+++ b/script/deploy/DeployDopplerERC20V1Factory.s.sol
@@ -1,65 +1,96 @@
-/// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { LibString } from "solady/utils/LibString.sol";
 import { DopplerERC20V1Factory } from "src/tokens/DopplerERC20V1Factory.sol";
 
-error UnexpectedAddress();
-
-contract DeployDopplerERC20V1FactoryScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
-
-        uint256[] memory targets = new uint256[](4);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.MONAD_MAINNET;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
-
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            vm.selectFork(forkOf[chainId]);
-            deployToChain(chainId);
-        }
+abstract contract DeployDopplerERC20V1Factory is DeployBase {
+    function _deployDopplerERC20V1Factory(DeployContext memory context)
+        internal
+        returns (address dopplerERC20V1Factory)
+    {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployDopplerERC20V1Factory(context, airlock);
     }
 
-    function deployToChain(uint256 chainId) internal {
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
+    function _deployDopplerERC20V1Factory(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address dopplerERC20V1Factory) {
+        bytes memory initCode = abi.encodePacked(type(DopplerERC20V1Factory).creationCode, abi.encode(airlock));
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, type(DopplerERC20V1Factory).name);
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+        bool alreadyDeployed;
+        (dopplerERC20V1Factory, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(DopplerERC20V1Factory).name,
+            DOPPLER_ERC20_V1_FACTORY_VERSION,
+            initCode
+        );
 
-        address dopplerERC20V1Factory = ICreateX(createX)
-            .deployCreate3(salt, abi.encodePacked(type(DopplerERC20V1Factory).creationCode, abi.encode(airlock)));
-        require(dopplerERC20V1Factory == expectedAddress, UnexpectedAddress());
-        vm.stopBroadcast();
+        address implementation = _verifyDopplerERC20V1FactoryDeployment(dopplerERC20V1Factory, airlock);
+        _setConfigAddress(context, "doppler_erc20_v1_factory", dopplerERC20V1Factory);
+        _setConfigAddress(context, "doppler_erc20_v1_implementation", implementation);
 
-        address implementation = DopplerERC20V1Factory(dopplerERC20V1Factory).IMPLEMENTATION();
-
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
-            config.set("doppler_erc20_v1_factory", dopplerERC20V1Factory);
-            config.set("doppler_erc20_v1_implementation", implementation);
+        if (alreadyDeployed) {
+            console.log("DopplerERC20V1Factory already deployed to:", dopplerERC20V1Factory);
+        } else {
+            console.log("DopplerERC20V1Factory deployed to:", dopplerERC20V1Factory);
         }
-        console.log(
-            "DopplerERC20V1Factory was deployed to",
-            LibString.toHexString(uint256(uint160(dopplerERC20V1Factory))),
-            "on chain ID",
-            LibString.toString(chainId)
+        console.log("DopplerERC20V1 implementation deployed to:", implementation);
+    }
+
+    function _verifyDopplerERC20V1FactoryDeployment(
+        address addr,
+        address airlock
+    ) internal view returns (address implementation) {
+        DopplerERC20V1Factory factory = DopplerERC20V1Factory(addr);
+        require(address(factory.airlock()) == airlock, "DopplerERC20V1Factory airlock mismatch");
+
+        implementation = factory.IMPLEMENTATION();
+        require(
+            implementation != address(0) && implementation.code.length != 0, "Invalid DopplerERC20V1 implementation"
         );
-        console.log(
-            "DopplerERC20V1 implementation was deployed to",
-            LibString.toHexString(uint256(uint160(implementation))),
-            "on chain ID",
-            LibString.toString(chainId)
-        );
+    }
+}
+
+contract DeployDopplerERC20V1FactoryScript is DeployDopplerERC20V1Factory {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address dopplerERC20V1Factory) {
+        return _deployDopplerERC20V1Factory(_deployContext());
+    }
+}
+
+contract DeployDopplerERC20V1FactoryScriptEthereum is DeployDopplerERC20V1FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployDopplerERC20V1FactoryScriptMonad is DeployDopplerERC20V1FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployDopplerERC20V1FactoryScriptBase is DeployDopplerERC20V1FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployDopplerERC20V1FactoryScriptBaseSepolia is DeployDopplerERC20V1FactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployDopplerHookInitializer.s.sol
+++ b/script/deploy/DeployDopplerHookInitializer.s.sol
@@ -1,56 +1,131 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
+import { Hooks } from "@v4-core/libraries/Hooks.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { LibString } from "solady/utils/LibString.sol";
 import { DopplerHookInitializer } from "src/initializers/DopplerHookInitializer.sol";
-import { MineDopplerHookInitializerParams, mineDopplerHookInitializer } from "test/shared/AirlockMiner.sol";
 
-contract DeployDopplerHookInitializerScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+uint160 constant DOPPLER_HOOK_INITIALIZER_FLAGS = uint160(
+    Hooks.BEFORE_INITIALIZE_FLAG | Hooks.AFTER_ADD_LIQUIDITY_FLAG | Hooks.AFTER_REMOVE_LIQUIDITY_FLAG
+        | Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG
+);
 
-        uint256[] memory targets = new uint256[](4);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.MONAD_MAINNET;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
+abstract contract DeployDopplerHookInitializer is DeployBase {
+    function _deployDopplerHookInitializer(DeployContext memory context)
+        internal
+        returns (address dopplerHookInitializer)
+    {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployDopplerHookInitializer(context, airlock);
+    }
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            vm.selectFork(forkOf[chainId]);
-            deployToChain(chainId);
+    function _deployDopplerHookInitializer(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address dopplerHookInitializer) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        bytes memory initCode =
+            abi.encodePacked(type(DopplerHookInitializer).creationCode, abi.encode(airlock, poolManager));
+        (bytes32 salt, address expected) = _mineDopplerHookInitializerSalt(context, airlock, poolManager);
+
+        bool alreadyDeployed;
+        (dopplerHookInitializer, alreadyDeployed) = _deployOrUseExistingCreate3(context, salt, expected, initCode);
+
+        _verifyDopplerHookInitializerDeployment(dopplerHookInitializer, airlock, poolManager);
+        _setConfigAddress(context, "doppler_hook_initializer", dopplerHookInitializer);
+
+        if (alreadyDeployed) {
+            console.log("DopplerHookInitializer already deployed to:", dopplerHookInitializer);
+        } else {
+            console.log("DopplerHookInitializer deployed to:", dopplerHookInitializer);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+    function _mineDopplerHookInitializerSalt(
+        DeployContext memory context,
+        address airlock,
+        address poolManager
+    ) internal view returns (bytes32 salt, address expected) {
+        bytes32 baseSalt = context.protocolDeployer
+            .generateSalt(type(DopplerHookInitializer).name, MULTICURVE_INITIALIZER_VERSION);
 
-        vm.startBroadcast();
-        (bytes32 salt, address deployedTo) =
-            mineDopplerHookInitializer(MineDopplerHookInitializerParams({ sender: msg.sender, deployer: createX }));
-        address dopplerHookInitializer = ICreateX(createX)
-            .deployCreate3(
-                salt, abi.encodePacked(type(DopplerHookInitializer).creationCode, abi.encode(airlock, poolManager))
-            );
-        require(dopplerHookInitializer == deployedTo, "Unexpected deployed address");
-        vm.stopBroadcast();
+        for (uint88 seed; seed < type(uint88).max; seed++) {
+            salt = bytes32(uint256(baseSalt) + seed);
+            expected = _computeProtocolCreate3Address(context.protocolDeployer, salt);
 
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
-            config.set("doppler_hook_initializer", dopplerHookInitializer);
+            if (
+                uint160(expected) & Hooks.ALL_HOOK_MASK == DOPPLER_HOOK_INITIALIZER_FLAGS
+                    && (expected.code.length == 0
+                        || _isDopplerHookInitializerDeployment(expected, airlock, poolManager))
+            ) {
+                return (salt, expected);
+            }
         }
-        console.log(
-            "DopplerHookInitializer was deployed to",
-            LibString.toHexString(uint256(uint160(dopplerHookInitializer))),
-            "on chain ID",
-            LibString.toString(chainId)
-        );
+
+        revert("DopplerHookInitializer salt not found");
+    }
+
+    function _isDopplerHookInitializerDeployment(
+        address addr,
+        address airlock,
+        address poolManager
+    ) internal view returns (bool) {
+        (bool airlockSuccess, bytes memory airlockResult) =
+            addr.staticcall(abi.encodeWithSelector(bytes4(keccak256("airlock()"))));
+        if (!airlockSuccess || airlockResult.length != 32 || abi.decode(airlockResult, (address)) != airlock) {
+            return false;
+        }
+
+        (bool poolManagerSuccess, bytes memory poolManagerResult) =
+            addr.staticcall(abi.encodeWithSelector(bytes4(keccak256("poolManager()"))));
+        return
+            poolManagerSuccess && poolManagerResult.length == 32
+                && abi.decode(poolManagerResult, (address)) == poolManager;
+    }
+
+    function _verifyDopplerHookInitializerDeployment(address addr, address airlock, address poolManager) internal view {
+        DopplerHookInitializer initializer = DopplerHookInitializer(payable(addr));
+        require(address(initializer.airlock()) == airlock, "DopplerHookInitializer airlock mismatch");
+        require(address(initializer.poolManager()) == poolManager, "DopplerHookInitializer pool manager mismatch");
+    }
+}
+
+contract DeployDopplerHookInitializerScript is DeployDopplerHookInitializer {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address dopplerHookInitializer) {
+        return _deployDopplerHookInitializer(_deployContext());
+    }
+}
+
+contract DeployDopplerHookInitializerScriptEthereum is DeployDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployDopplerHookInitializerScriptMonad is DeployDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployDopplerHookInitializerScriptBase is DeployDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployDopplerHookInitializerScriptBaseSepolia is DeployDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployDopplerHookMigrator.s.sol
+++ b/script/deploy/DeployDopplerHookMigrator.s.sol
@@ -1,56 +1,151 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { Hooks } from "@v4-core/libraries/Hooks.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { StreamableFeesLockerV2 } from "src/lockers/StreamableFeesLockerV2.sol";
 import { DopplerHookMigrator } from "src/migrators/DopplerHookMigrator.sol";
-import { MineDopplerHookMigratorParams, mineDopplerHookMigrator } from "test/shared/AirlockMiner.sol";
 
-contract DeployDopplerHookMigratorScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+uint160 constant DOPPLER_HOOK_MIGRATOR_FLAGS = uint160(
+    Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG
+);
 
-        uint256[] memory targets = new uint256[](5);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
-        targets[4] = ChainIds.MONAD_MAINNET;
+abstract contract DeployDopplerHookMigrator is DeployBase {
+    function _deployDopplerHookMigrator(DeployContext memory context) internal returns (address dopplerHookMigrator) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        address topUpDistributor = context.config.get(context.chainId, "top_up_distributor").toAddress();
+        address locker = context.config.get(context.chainId, "streamable_fees_locker_v2").toAddress();
+        return _deployDopplerHookMigrator(context, airlock, topUpDistributor, locker);
+    }
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+    function _deployDopplerHookMigrator(
+        DeployContext memory context,
+        address airlock,
+        address topUpDistributor,
+        address locker
+    ) internal returns (address dopplerHookMigrator) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        bytes memory initCode = abi.encodePacked(
+            type(DopplerHookMigrator).creationCode, abi.encode(airlock, poolManager, locker, topUpDistributor)
+        );
+        (bytes32 salt, address expected) =
+            _mineDopplerHookMigratorSalt(context, airlock, poolManager, locker, topUpDistributor);
+
+        bool alreadyDeployed;
+        (dopplerHookMigrator, alreadyDeployed) = _deployOrUseExistingCreate3(context, salt, expected, initCode);
+
+        _verifyDopplerHookMigratorDeployment(dopplerHookMigrator, airlock, poolManager, locker, topUpDistributor);
+        _setConfigAddress(context, "doppler_hook_migrator", dopplerHookMigrator);
+
+        if (alreadyDeployed) {
+            console.log("DopplerHookMigrator already deployed to:", dopplerHookMigrator);
+        } else {
+            console.log("DopplerHookMigrator deployed to:", dopplerHookMigrator);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _mineDopplerHookMigratorSalt(
+        DeployContext memory context,
+        address airlock,
+        address poolManager,
+        address locker,
+        address topUpDistributor
+    ) internal view returns (bytes32 salt, address expected) {
+        bytes32 baseSalt = context.protocolDeployer
+            .generateSalt(type(DopplerHookMigrator).name, DOPPLER_HOOK_MIGRATOR_VERSION);
 
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
-        address multiSig = config.get("airlock_multisig").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
-        address topUpDistributor = config.get("top_up_distributor").toAddress();
-        address locker = config.get("streamable_fees_locker_v2").toAddress();
+        for (uint88 seed; seed < type(uint88).max; seed++) {
+            salt = bytes32(uint256(baseSalt) + seed);
+            expected = _computeProtocolCreate3Address(context.protocolDeployer, salt);
 
-        vm.startBroadcast();
+            if (
+                uint160(expected) & Hooks.ALL_HOOK_MASK == DOPPLER_HOOK_MIGRATOR_FLAGS
+                    && (expected.code.length == 0
+                        || _isDopplerHookMigratorDeployment(expected, airlock, poolManager, locker, topUpDistributor))
+                    && expected != 0x8bBbE586F9A902c15A759FC134A99a2d28bc20c4
+                    && expected != 0xF848fEa3329185529B50228BCb36f3B5A60960C4
+            ) {
+                return (salt, expected);
+            }
+        }
 
-        (bytes32 migratorSalt, address migratorDeployedTo) =
-            mineDopplerHookMigrator(MineDopplerHookMigratorParams({ sender: msg.sender, deployer: createX }));
-        address dopplerHookMigrator = ICreateX(createX)
-            .deployCreate3(
-                migratorSalt,
-                abi.encodePacked(
-                    type(DopplerHookMigrator).creationCode, abi.encode(airlock, poolManager, locker, topUpDistributor)
-                )
-            );
-        require(dopplerHookMigrator == migratorDeployedTo, "Unexpected deployed address");
+        revert("DopplerHookMigrator salt not found");
+    }
 
-        vm.stopBroadcast();
-        config.set("doppler_hook_migrator", dopplerHookMigrator);
+    function _isDopplerHookMigratorDeployment(
+        address addr,
+        address airlock,
+        address poolManager,
+        address locker,
+        address topUpDistributor
+    ) internal view returns (bool) {
+        return _staticAddressMatches(addr, abi.encodeWithSelector(bytes4(keccak256("airlock()"))), airlock)
+            && _staticAddressMatches(addr, abi.encodeWithSelector(bytes4(keccak256("poolManager()"))), poolManager)
+            && _staticAddressMatches(addr, abi.encodeWithSelector(bytes4(keccak256("locker()"))), locker)
+            && _staticAddressMatches(
+            addr, abi.encodeWithSelector(bytes4(keccak256("TOP_UP_DISTRIBUTOR()"))), topUpDistributor
+        );
+    }
+
+    function _staticAddressMatches(
+        address target,
+        bytes memory callData,
+        address expected
+    ) internal view returns (bool) {
+        (bool success, bytes memory result) = target.staticcall(callData);
+        return success && result.length == 32 && abi.decode(result, (address)) == expected;
+    }
+
+    function _verifyDopplerHookMigratorDeployment(
+        address addr,
+        address airlock,
+        address poolManager,
+        address locker,
+        address topUpDistributor
+    ) internal view {
+        DopplerHookMigrator migrator = DopplerHookMigrator(payable(addr));
+        require(address(migrator.airlock()) == airlock, "DopplerHookMigrator airlock mismatch");
+        require(address(migrator.poolManager()) == poolManager, "DopplerHookMigrator pool manager mismatch");
+        require(address(migrator.locker()) == locker, "DopplerHookMigrator locker mismatch");
+        require(address(migrator.TOP_UP_DISTRIBUTOR()) == topUpDistributor, "DopplerHookMigrator top-up mismatch");
+    }
+}
+
+contract DeployDopplerHookMigratorScript is DeployDopplerHookMigrator {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address dopplerHookMigrator) {
+        return _deployDopplerHookMigrator(_deployContext());
+    }
+}
+
+contract DeployDopplerHookMigratorScriptEthereum is DeployDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployDopplerHookMigratorScriptMonad is DeployDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployDopplerHookMigratorScriptBase is DeployDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployDopplerHookMigratorScriptBaseSepolia is DeployDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployDopplerLensQuoter.s.sol
+++ b/script/deploy/DeployDopplerLensQuoter.s.sol
@@ -1,57 +1,74 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { TypeKind, Variable } from "forge-std/LibVariable.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { LibString } from "solady/utils/LibString.sol";
 import { DopplerLensQuoter } from "src/lens/DopplerLens.sol";
 
-contract DeployDopplerLensQuoterScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployDopplerLensQuoter is DeployBase {
+    function _deployDopplerLensQuoter(DeployContext memory context) internal returns (address dopplerLensQuoter) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        address stateView = context.config.get(context.chainId, "uniswap_v4_state_view").toAddress();
+        bytes memory initCode =
+            abi.encodePacked(type(DopplerLensQuoter).creationCode, abi.encode(poolManager, stateView));
 
-        uint256[] memory targets = new uint256[](4);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.MONAD_MAINNET;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
+        bool alreadyDeployed;
+        (dopplerLensQuoter, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(DopplerLensQuoter).name, DOPPLER_LENS_QUOTER_VERSION, initCode
+        );
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            vm.selectFork(forkOf[chainId]);
-            deployToChain(chainId);
+        _verifyDopplerLensQuoterDeployment(dopplerLensQuoter, poolManager, stateView);
+        _setConfigAddress(context, "doppler_lens_quoter", dopplerLensQuoter);
+
+        if (alreadyDeployed) {
+            console.log("DopplerLensQuoter already deployed to:", dopplerLensQuoter);
+        } else {
+            console.log("DopplerLensQuoter deployed to:", dopplerLensQuoter);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        address createX = config.get("create_x").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
-        address stateView = config.get("uniswap_v4_state_view").toAddress();
+    function _verifyDopplerLensQuoterDeployment(address addr, address poolManager, address stateView) internal view {
+        DopplerLensQuoter quoter = DopplerLensQuoter(addr);
+        require(address(quoter.poolManager()) == poolManager, "DopplerLensQuoter pool manager mismatch");
+        require(address(quoter.stateView()) == stateView, "DopplerLensQuoter state view mismatch");
+    }
+}
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, type(DopplerLensQuoter).name);
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+contract DeployDopplerLensQuoterScript is DeployDopplerLensQuoter {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        address dopplerLensQuoter = ICreateX(createX)
-            .deployCreate3(
-                salt, abi.encodePacked(type(DopplerLensQuoter).creationCode, abi.encode(poolManager, stateView))
-            );
-        require(dopplerLensQuoter == expectedAddress, "Unexpected deployed address");
-        vm.stopBroadcast();
+    function run() public virtual {
+        deploy();
+    }
 
-        // Only set the config if a broadcast has occurred
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) config.set("doppler_lens_quoter", dopplerLensQuoter);
-        console.log(
-            "DopplerLensQuoter was deployed to",
-            LibString.toHexString(uint256(uint160(dopplerLensQuoter))),
-            "on chain ID",
-            LibString.toString(chainId)
-        );
+    function deploy() public returns (address dopplerLensQuoter) {
+        return _deployDopplerLensQuoter(_deployContext());
+    }
+}
+
+contract DeployDopplerLensQuoterScriptEthereum is DeployDopplerLensQuoterScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployDopplerLensQuoterScriptMonad is DeployDopplerLensQuoterScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployDopplerLensQuoterScriptBase is DeployDopplerLensQuoterScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployDopplerLensQuoterScriptBaseSepolia is DeployDopplerLensQuoterScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployGovernanceFactory.s.sol
+++ b/script/deploy/DeployGovernanceFactory.s.sol
@@ -1,42 +1,79 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
 import { GovernanceFactory } from "src/governance/GovernanceFactory.sol";
 
-contract DeployGovernanceFactoryScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployGovernanceFactory is DeployBase {
+    function _deployGovernanceFactory(DeployContext memory context) internal returns (address governanceFactory) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployGovernanceFactory(context, airlock);
+    }
 
-        uint256[] memory targets = new uint256[](2);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
+    function _deployGovernanceFactory(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address governanceFactory) {
+        bytes memory initCode = abi.encodePacked(type(GovernanceFactory).creationCode, abi.encode(airlock));
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        bool alreadyDeployed;
+        (governanceFactory, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(GovernanceFactory).name, GOVERNANCE_FACTORY_VERSION, initCode
+        );
+
+        _verifyGovernanceFactoryDeployment(governanceFactory, airlock);
+        _setConfigAddress(context, "governance_factory", governanceFactory);
+
+        if (alreadyDeployed) {
+            console.log("GovernanceFactory already deployed to:", governanceFactory);
+        } else {
+            console.log("GovernanceFactory deployed to:", governanceFactory);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _verifyGovernanceFactoryDeployment(address addr, address airlock) internal view {
+        GovernanceFactory factory = GovernanceFactory(addr);
+        require(address(factory.airlock()) == airlock, "GovernanceFactory airlock mismatch");
+        require(address(factory.timelockFactory()) != address(0), "GovernanceFactory timelock factory missing");
+    }
+}
 
-        address createX = config.get("create_x").toAddress();
-        address airlock = config.get("airlock").toAddress();
+contract DeployGovernanceFactoryScript is DeployGovernanceFactory {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, type(GovernanceFactory).name);
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+    function run() public virtual {
+        deploy();
+    }
 
-        address governanceFactory = ICreateX(createX)
-            .deployCreate3(salt, abi.encodePacked(type(GovernanceFactory).creationCode, abi.encode(airlock)));
-        require(governanceFactory == expectedAddress, "Unexpected deployed address");
+    function deploy() public returns (address governanceFactory) {
+        return _deployGovernanceFactory(_deployContext());
+    }
+}
 
-        vm.stopBroadcast();
-        config.set("governance_factory", governanceFactory);
+contract DeployGovernanceFactoryScriptEthereum is DeployGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployGovernanceFactoryScriptMonad is DeployGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployGovernanceFactoryScriptBase is DeployGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployGovernanceFactoryScriptBaseSepolia is DeployGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployLaunchpadGovernanceFactory.s.sol
+++ b/script/deploy/DeployLaunchpadGovernanceFactory.s.sol
@@ -1,52 +1,82 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
 import { LaunchpadGovernanceFactory } from "src/governance/LaunchpadGovernanceFactory.sol";
 
-struct ScriptData {
-    uint256 chainId;
-}
+abstract contract DeployLaunchpadGovernanceFactory is DeployBase {
+    function _deployLaunchpadGovernanceFactory(DeployContext memory context)
+        internal
+        returns (address launchpadGovernanceFactory)
+    {
+        bool alreadyDeployed;
+        (launchpadGovernanceFactory, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(LaunchpadGovernanceFactory).name,
+            LAUNCHPAD_GOVERNANCE_FACTORY_VERSION,
+            abi.encodePacked(type(LaunchpadGovernanceFactory).creationCode)
+        );
 
-abstract contract DeployLaunchpadGovernanceFactoryScript is Script {
-    ScriptData internal _scriptData;
+        _verifyLaunchpadGovernanceFactoryDeployment(launchpadGovernanceFactory);
+        _setConfigAddress(context, "launchpad_governance_factory", launchpadGovernanceFactory);
 
-    function setUp() public virtual;
+        if (alreadyDeployed) {
+            console.log("LaunchpadGovernanceFactory already deployed to:", launchpadGovernanceFactory);
+        } else {
+            console.log("LaunchpadGovernanceFactory deployed to:", launchpadGovernanceFactory);
+        }
+    }
 
-    function run() public {
-        vm.startBroadcast();
-        require(block.chainid == _scriptData.chainId, "Invalid chainId");
-        new LaunchpadGovernanceFactory();
-        vm.stopBroadcast();
+    function _verifyLaunchpadGovernanceFactoryDeployment(address addr) internal view {
+        address multisig = address(0xbeef);
+        (bool success, bytes memory result) =
+            addr.staticcall(abi.encodeCall(LaunchpadGovernanceFactory.create, (address(0), abi.encode(multisig))));
+        require(success, "LaunchpadGovernanceFactory interface check failed");
+
+        (address governance, address timelockController) = abi.decode(result, (address, address));
+        require(governance == address(0xdead), "LaunchpadGovernanceFactory governance mismatch");
+        require(timelockController == multisig, "LaunchpadGovernanceFactory timelock mismatch");
     }
 }
 
-/// @dev forge script DeployLaunchpadGovernanceFactoryEthereumMainnetScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $ETH_MAINNET_RPC_URL
-contract DeployLaunchpadGovernanceFactoryEthereumMainnetScript is DeployLaunchpadGovernanceFactoryScript {
+contract DeployLaunchpadGovernanceFactoryScript is DeployLaunchpadGovernanceFactory {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address launchpadGovernanceFactory) {
+        return _deployLaunchpadGovernanceFactory(_deployContext());
+    }
+}
+
+contract DeployLaunchpadGovernanceFactoryScriptEthereum is DeployLaunchpadGovernanceFactoryScript {
     function setUp() public override {
-        _scriptData = ScriptData({ chainId: ChainIds.ETH_MAINNET });
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
     }
 }
 
-/// @dev forge script DeployLaunchpadGovernanceFactoryBaseScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $BASE_MAINNET_RPC_URL
-contract DeployLaunchpadGovernanceFactoryBaseScript is DeployLaunchpadGovernanceFactoryScript {
+contract DeployLaunchpadGovernanceFactoryScriptMonad is DeployLaunchpadGovernanceFactoryScript {
     function setUp() public override {
-        _scriptData = ScriptData({ chainId: ChainIds.BASE_MAINNET });
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
     }
 }
 
-/// @dev forge script DeployLaunchpadGovernanceFactoryBaseSepoliaScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $BASE_SEPOLIA_RPC_URL
-contract DeployLaunchpadGovernanceFactoryBaseSepoliaScript is DeployLaunchpadGovernanceFactoryScript {
+contract DeployLaunchpadGovernanceFactoryScriptBase is DeployLaunchpadGovernanceFactoryScript {
     function setUp() public override {
-        _scriptData = ScriptData({ chainId: ChainIds.BASE_SEPOLIA });
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
     }
 }
 
-/// @dev forge script DeployLaunchpadGovernanceFactoryMonadTestnetScript --private-key $PRIVATE_KEY --broadcast --slow --verify --rpc-url $MONAD_TESTNET_RPC_URL
-contract DeployLaunchpadGovernanceFactoryMonadTestnetScript is DeployLaunchpadGovernanceFactoryScript {
+contract DeployLaunchpadGovernanceFactoryScriptBaseSepolia is DeployLaunchpadGovernanceFactoryScript {
     function setUp() public override {
-        _scriptData = ScriptData({ chainId: ChainIds.MONAD_TESTNET });
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }
-

--- a/script/deploy/DeployLockableUniswapV3Initializer.s.sol
+++ b/script/deploy/DeployLockableUniswapV3Initializer.s.sol
@@ -1,120 +1,93 @@
-/// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { IUniswapV3Factory } from "@v3-core/interfaces/IUniswapV3Factory.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { LibString } from "solady/utils/LibString.sol";
 import { LockableUniswapV3Initializer } from "src/initializers/LockableUniswapV3Initializer.sol";
 
-struct ScriptData {
-    address airlock;
-    address uniswapV3Factory;
-    uint256 chainId;
-}
-
-abstract contract DeployLockableUniswapV3InitializerScript is Script, Config {
-    ScriptData internal _scriptData;
-
-    function setUp() public virtual {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployLockableUniswapV3Initializer is DeployBase {
+    function _deployLockableUniswapV3Initializer(DeployContext memory context)
+        internal
+        returns (address lockableUniswapV3Initializer)
+    {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployLockableUniswapV3Initializer(context, airlock);
     }
 
-    function run() public {
-        vm.startBroadcast();
-        LockableUniswapV3Initializer initializer =
-            new LockableUniswapV3Initializer(_scriptData.airlock, IUniswapV3Factory(_scriptData.uniswapV3Factory));
-        vm.stopBroadcast();
+    function _deployLockableUniswapV3Initializer(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address lockableUniswapV3Initializer) {
+        address uniswapV3Factory = context.config.get(context.chainId, "uniswap_v3_factory").toAddress();
+        bytes memory initCode =
+            abi.encodePacked(type(LockableUniswapV3Initializer).creationCode, abi.encode(airlock, uniswapV3Factory));
 
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
-            config.set("lockable_uniswap_v3_initializer", address(initializer));
-        }
-        console.log(
-            "LockableUniswapV3Initializer was deployed to",
-            LibString.toHexString(uint256(uint160(address(initializer)))),
-            "on chain ID",
-            LibString.toString(_scriptData.chainId)
+        bool alreadyDeployed;
+        (lockableUniswapV3Initializer, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(LockableUniswapV3Initializer).name,
+            STATIC_INITIALIZER_VERSION,
+            initCode
         );
+
+        _verifyLockableUniswapV3InitializerDeployment(lockableUniswapV3Initializer, airlock, uniswapV3Factory);
+        _setConfigAddress(context, "lockable_uniswap_v3_initializer", lockableUniswapV3Initializer);
+
+        if (alreadyDeployed) {
+            console.log("LockableUniswapV3Initializer already deployed to:", lockableUniswapV3Initializer);
+        } else {
+            console.log("LockableUniswapV3Initializer deployed to:", lockableUniswapV3Initializer);
+        }
+    }
+
+    function _verifyLockableUniswapV3InitializerDeployment(
+        address addr,
+        address airlock,
+        address uniswapV3Factory
+    ) internal view {
+        LockableUniswapV3Initializer initializer = LockableUniswapV3Initializer(payable(addr));
+        require(address(initializer.airlock()) == airlock, "LockableUniswapV3Initializer airlock mismatch");
+        require(address(initializer.factory()) == uniswapV3Factory, "LockableUniswapV3Initializer factory mismatch");
     }
 }
 
-/// @dev forge script DeployLockableUniswapV3InitializerEthereumMainnet --private-key $PRIVATE_KEY --verify --slow --broadcast
-contract DeployLockableUniswapV3InitializerEthereumMainnet is DeployLockableUniswapV3InitializerScript {
-    function setUp() public override {
-        super.setUp();
-        vm.selectFork(forkOf[ChainIds.ETH_MAINNET]);
-        _scriptData = ScriptData({
-            airlock: config.get("airlock").toAddress(),
-            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
-            chainId: ChainIds.ETH_MAINNET
-        });
+contract DeployLockableUniswapV3InitializerScript is DeployLockableUniswapV3Initializer {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address lockableUniswapV3Initializer) {
+        return _deployLockableUniswapV3Initializer(_deployContext());
     }
 }
 
-/// @dev forge script DeployLockableUniswapV3InitializerBaseSepolia --private-key $PRIVATE_KEY --verify --slow --broadcast
-contract DeployLockableUniswapV3InitializerBaseSepolia is DeployLockableUniswapV3InitializerScript {
+contract DeployLockableUniswapV3InitializerScriptEthereum is DeployLockableUniswapV3InitializerScript {
     function setUp() public override {
-        super.setUp();
-        vm.selectFork(forkOf[ChainIds.BASE_SEPOLIA]);
-        _scriptData = ScriptData({
-            airlock: config.get("airlock").toAddress(),
-            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
-            chainId: ChainIds.BASE_SEPOLIA
-        });
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
     }
 }
 
-/// @dev forge script DeployLockableUniswapV3InitializerBase --private-key $PRIVATE_KEY --verify --slow --broadcast
-contract DeployLockableUniswapV3InitializerBase is DeployLockableUniswapV3InitializerScript {
+contract DeployLockableUniswapV3InitializerScriptMonad is DeployLockableUniswapV3InitializerScript {
     function setUp() public override {
-        super.setUp();
-        vm.selectFork(forkOf[ChainIds.BASE_MAINNET]);
-        _scriptData = ScriptData({
-            airlock: config.get("airlock").toAddress(),
-            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
-            chainId: ChainIds.BASE_MAINNET
-        });
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
     }
 }
 
-/// @dev forge script DeployLockableUniswapV3InitializerUnichainSepolia --private-key $PRIVATE_KEY --verify --slow --broadcast
-contract DeployLockableUniswapV3InitializerUnichainSepolia is DeployLockableUniswapV3InitializerScript {
+contract DeployLockableUniswapV3InitializerScriptBase is DeployLockableUniswapV3InitializerScript {
     function setUp() public override {
-        super.setUp();
-        vm.selectFork(forkOf[ChainIds.UNICHAIN_SEPOLIA]);
-        _scriptData = ScriptData({
-            airlock: config.get("airlock").toAddress(),
-            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
-            chainId: ChainIds.UNICHAIN_SEPOLIA
-        });
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
     }
 }
 
-/// @dev forge script DeployLockableUniswapV3InitializerUnichain --private-key $PRIVATE_KEY --verify --slow --broadcast
-contract DeployLockableUniswapV3InitializerUnichain is DeployLockableUniswapV3InitializerScript {
+contract DeployLockableUniswapV3InitializerScriptBaseSepolia is DeployLockableUniswapV3InitializerScript {
     function setUp() public override {
-        super.setUp();
-        vm.selectFork(forkOf[ChainIds.UNICHAIN_MAINNET]);
-        _scriptData = ScriptData({
-            airlock: config.get("airlock").toAddress(),
-            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
-            chainId: ChainIds.UNICHAIN_MAINNET
-        });
-    }
-}
-
-/// @dev forge script DeployLockableUniswapV3InitializerMonad --private-key $PRIVATE_KEY --verify --slow --broadcast
-contract DeployLockableUniswapV3InitializerMonad is DeployLockableUniswapV3InitializerScript {
-    function setUp() public override {
-        super.setUp();
-        vm.selectFork(forkOf[ChainIds.MONAD_MAINNET]);
-        _scriptData = ScriptData({
-            airlock: config.get("airlock").toAddress(),
-            uniswapV3Factory: config.get("uniswap_v3_factory").toAddress(),
-            chainId: ChainIds.MONAD_MAINNET
-        });
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployNoOpGovernanceFactory.s.sol
+++ b/script/deploy/DeployNoOpGovernanceFactory.s.sol
@@ -1,42 +1,75 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt } from "script/utils/CreateX.sol";
 import { NoOpGovernanceFactory } from "src/governance/NoOpGovernanceFactory.sol";
 
-contract DeployNoOpGovernanceFactoryScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployNoOpGovernanceFactory is DeployBase {
+    function _deployNoOpGovernanceFactory(DeployContext memory context)
+        internal
+        returns (address noOpGovernanceFactory)
+    {
+        bool alreadyDeployed;
+        (noOpGovernanceFactory, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(NoOpGovernanceFactory).name,
+            NO_OP_GOVERNANCE_FACTORY_VERSION,
+            abi.encodePacked(type(NoOpGovernanceFactory).creationCode)
+        );
 
-        uint256[] memory targets = new uint256[](2);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
+        _verifyNoOpGovernanceFactoryDeployment(noOpGovernanceFactory);
+        _setConfigAddress(context, "no_op_governance_factory", noOpGovernanceFactory);
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        if (alreadyDeployed) {
+            console.log("NoOpGovernanceFactory already deployed to:", noOpGovernanceFactory);
+        } else {
+            console.log("NoOpGovernanceFactory deployed to:", noOpGovernanceFactory);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
-
-        address createX = config.get("create_x").toAddress();
-
-        vm.startBroadcast();
-        bytes32 salt = bytes32((uint256(uint160(msg.sender)) << 96) + uint256(0xdeadb055deadb055));
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
-
-        address noOpGovernanceFactory =
-            ICreateX(createX).deployCreate3(salt, abi.encodePacked(type(NoOpGovernanceFactory).creationCode));
-        require(noOpGovernanceFactory == expectedAddress, "Unexpected deployed address");
-
-        vm.stopBroadcast();
-        config.set("no_op_governance_factory", noOpGovernanceFactory);
+    function _verifyNoOpGovernanceFactoryDeployment(address addr) internal view {
+        require(NoOpGovernanceFactory(addr).DEAD_ADDRESS() == address(0xdead), "NoOpGovernanceFactory mismatch");
     }
 }
 
+contract DeployNoOpGovernanceFactoryScript is DeployNoOpGovernanceFactory {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address noOpGovernanceFactory) {
+        return _deployNoOpGovernanceFactory(_deployContext());
+    }
+}
+
+contract DeployNoOpGovernanceFactoryScriptEthereum is DeployNoOpGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployNoOpGovernanceFactoryScriptMonad is DeployNoOpGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployNoOpGovernanceFactoryScriptBase is DeployNoOpGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployNoOpGovernanceFactoryScriptBaseSepolia is DeployNoOpGovernanceFactoryScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
+    }
+}

--- a/script/deploy/DeployNoOpMigrator.s.sol
+++ b/script/deploy/DeployNoOpMigrator.s.sol
@@ -1,42 +1,77 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt } from "script/utils/CreateX.sol";
 import { NoOpMigrator } from "src/migrators/NoOpMigrator.sol";
 
-contract DeployNoOpMigratorScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployNoOpMigrator is DeployBase {
+    function _deployNoOpMigrator(DeployContext memory context) internal returns (address noOpMigrator) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployNoOpMigrator(context, airlock);
+    }
 
-        uint256[] memory targets = new uint256[](2);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
+    function _deployNoOpMigrator(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address noOpMigrator) {
+        bytes memory initCode = abi.encodePacked(type(NoOpMigrator).creationCode, abi.encode(airlock));
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        bool alreadyDeployed;
+        (noOpMigrator, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(NoOpMigrator).name, NO_OP_MIGRATOR_VERSION, initCode
+        );
+
+        _verifyNoOpMigratorDeployment(noOpMigrator, airlock);
+        _setConfigAddress(context, "no_op_migrator", noOpMigrator);
+
+        if (alreadyDeployed) {
+            console.log("NoOpMigrator already deployed to:", noOpMigrator);
+        } else {
+            console.log("NoOpMigrator deployed to:", noOpMigrator);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _verifyNoOpMigratorDeployment(address addr, address airlock) internal view {
+        require(address(NoOpMigrator(addr).airlock()) == airlock, "NoOpMigrator airlock mismatch");
+    }
+}
 
-        address createX = config.get("create_x").toAddress();
-        address airlock = config.get("airlock").toAddress();
+contract DeployNoOpMigratorScript is DeployNoOpMigrator {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        vm.startBroadcast();
-        bytes32 salt = bytes32((uint256(uint160(msg.sender)) << 96) + uint256(0xdeaddeaddeaddead));
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+    function run() public virtual {
+        deploy();
+    }
 
-        address noOpMigrator = ICreateX(createX)
-            .deployCreate3(salt, abi.encodePacked(type(NoOpMigrator).creationCode, abi.encode(airlock)));
-        require(noOpMigrator == expectedAddress, "Unexpected deployed address");
+    function deploy() public returns (address noOpMigrator) {
+        return _deployNoOpMigrator(_deployContext());
+    }
+}
 
-        vm.stopBroadcast();
-        config.set("no_op_migrator", noOpMigrator);
+contract DeployNoOpMigratorScriptEthereum is DeployNoOpMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployNoOpMigratorScriptMonad is DeployNoOpMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployNoOpMigratorScriptBase is DeployNoOpMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployNoOpMigratorScriptBaseSepolia is DeployNoOpMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployRehypeDopplerHookInitializer.s.sol
+++ b/script/deploy/DeployRehypeDopplerHookInitializer.s.sol
@@ -1,62 +1,101 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { LibString } from "solady/utils/LibString.sol";
 import { RehypeDopplerHookInitializer } from "src/dopplerHooks/RehypeDopplerHookInitializer.sol";
 
-contract DeployRehypeDopplerHookInitializerScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
-
-        uint256[] memory targets = new uint256[](4);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.MONAD_MAINNET;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
-
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            vm.selectFork(forkOf[chainId]);
-            deployToChain(chainId);
-        }
+abstract contract DeployRehypeDopplerHookInitializer is DeployBase {
+    function _deployRehypeDopplerHookInitializer(DeployContext memory context)
+        internal
+        returns (address rehypeDopplerHookInitializer)
+    {
+        address dopplerHookInitializer = context.config.get(context.chainId, "doppler_hook_initializer").toAddress();
+        return _deployRehypeDopplerHookInitializer(context, dopplerHookInitializer);
     }
 
-    function deployToChain(uint256 chainId) internal {
-        address createX = config.get("create_x").toAddress();
-        address dopplerHookInitializer = config.get("doppler_hook_initializer").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
-
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, "RehypeDopplerHookInitializer-6");
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), address(createX));
-
-        address rehypeDopplerHook = ICreateX(createX)
-            .deployCreate3(
-                salt,
-                abi.encodePacked(
-                    type(RehypeDopplerHookInitializer).creationCode, abi.encode(dopplerHookInitializer, poolManager)
-                )
-            );
-        require(rehypeDopplerHook == expectedAddress, "Unexpected deployed address");
-        vm.stopBroadcast();
-
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
-            config.set("rehype_doppler_hook_initializer", rehypeDopplerHook);
-            config.set("quoter", address(RehypeDopplerHookInitializer(payable(rehypeDopplerHook)).quoter()));
-        }
-        console.log(
-            "RehypeDopplerHookInitializer was deployed to",
-            LibString.toHexString(uint256(uint160(rehypeDopplerHook))),
-            "on chain ID",
-            LibString.toString(chainId)
+    function _deployRehypeDopplerHookInitializer(
+        DeployContext memory context,
+        address dopplerHookInitializer
+    ) internal returns (address rehypeDopplerHookInitializer) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        bytes memory initCode = abi.encodePacked(
+            type(RehypeDopplerHookInitializer).creationCode, abi.encode(dopplerHookInitializer, poolManager)
         );
+
+        bool alreadyDeployed;
+        (rehypeDopplerHookInitializer, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(RehypeDopplerHookInitializer).name,
+            REHYPE_DOPPLER_HOOK_INITIALIZER_VERSION,
+            initCode
+        );
+
+        address quoter = _verifyRehypeDopplerHookInitializerDeployment(
+            rehypeDopplerHookInitializer, dopplerHookInitializer, poolManager
+        );
+        _setConfigAddress(context, "rehype_doppler_hook_initializer", rehypeDopplerHookInitializer);
+        _setConfigAddress(context, "quoter", quoter);
+
+        if (alreadyDeployed) {
+            console.log("RehypeDopplerHookInitializer already deployed to:", rehypeDopplerHookInitializer);
+        } else {
+            console.log("RehypeDopplerHookInitializer deployed to:", rehypeDopplerHookInitializer);
+        }
+        console.log("RehypeDopplerHookInitializer quoter deployed to:", quoter);
+    }
+
+    function _verifyRehypeDopplerHookInitializerDeployment(
+        address addr,
+        address dopplerHookInitializer,
+        address poolManager
+    ) internal view returns (address quoter) {
+        RehypeDopplerHookInitializer hook = RehypeDopplerHookInitializer(payable(addr));
+        require(hook.INITIALIZER() == dopplerHookInitializer, "RehypeDopplerHookInitializer initializer mismatch");
+        require(address(hook.poolManager()) == poolManager, "RehypeDopplerHookInitializer pool manager mismatch");
+
+        quoter = address(hook.quoter());
+        require(quoter != address(0) && quoter.code.length != 0, "RehypeDopplerHookInitializer quoter missing");
     }
 }
 
+contract DeployRehypeDopplerHookInitializerScript is DeployRehypeDopplerHookInitializer {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address rehypeDopplerHookInitializer) {
+        return _deployRehypeDopplerHookInitializer(_deployContext());
+    }
+}
+
+contract DeployRehypeDopplerHookInitializerScriptEthereum is DeployRehypeDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployRehypeDopplerHookInitializerScriptMonad is DeployRehypeDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployRehypeDopplerHookInitializerScriptBase is DeployRehypeDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployRehypeDopplerHookInitializerScriptBaseSepolia is DeployRehypeDopplerHookInitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
+    }
+}

--- a/script/deploy/DeployRehypeDopplerHookMigrator.s.sol
+++ b/script/deploy/DeployRehypeDopplerHookMigrator.s.sol
@@ -1,59 +1,98 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { LibString } from "solady/utils/LibString.sol";
 import { RehypeDopplerHookMigrator } from "src/dopplerHooks/RehypeDopplerHookMigrator.sol";
 
-contract DeployRehypeHookMigratorScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
-
-        uint256[] memory targets = new uint256[](1);
-        //targets[0] = ChainIds.ETH_MAINNET;
-        targets[0] = ChainIds.MONAD_MAINNET;
-        //targets[2] = ChainIds.BASE_MAINNET;
-        //targets[3] = ChainIds.BASE_SEPOLIA;
-
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            vm.selectFork(forkOf[chainId]);
-            deployToChain(chainId);
-        }
+abstract contract DeployRehypeDopplerHookMigrator is DeployBase {
+    function _deployRehypeDopplerHookMigrator(DeployContext memory context)
+        internal
+        returns (address rehypeDopplerHookMigrator)
+    {
+        address migrator = context.config.get(context.chainId, "doppler_hook_migrator").toAddress();
+        return _deployRehypeDopplerHookMigrator(context, migrator);
     }
 
-    function deployToChain(uint256 chainId) internal {
-        address createX = config.get("create_x").toAddress();
-        address migrator = config.get("doppler_hook_migrator").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+    function _deployRehypeDopplerHookMigrator(
+        DeployContext memory context,
+        address migrator
+    ) internal returns (address rehypeDopplerHookMigrator) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        bytes memory initCode =
+            abi.encodePacked(type(RehypeDopplerHookMigrator).creationCode, abi.encode(migrator, poolManager));
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, "RehypeDopplerHookMigrator-5");
-        address expectedAddress = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), address(createX));
-
-        address rehypeDopplerHookMigrator = ICreateX(createX)
-            .deployCreate3(
-                salt, abi.encodePacked(type(RehypeDopplerHookMigrator).creationCode, abi.encode(migrator, poolManager))
-            );
-        require(rehypeDopplerHookMigrator == expectedAddress, "Unexpected deployed address");
-        vm.stopBroadcast();
-
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
-            config.set("rehype_doppler_hook_migrator", rehypeDopplerHookMigrator);
-            config.set("quoter", address(RehypeDopplerHookMigrator(payable(rehypeDopplerHookMigrator)).quoter()));
-        }
-        console.log(
-            "RehypeDopplerHookMigrator was deployed to",
-            LibString.toHexString(uint256(uint160(rehypeDopplerHookMigrator))),
-            "on chain ID",
-            LibString.toString(chainId)
+        bool alreadyDeployed;
+        (rehypeDopplerHookMigrator, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(RehypeDopplerHookMigrator).name,
+            REHYPE_DOPPLER_HOOK_MIGRATOR_VERSION,
+            initCode
         );
+
+        address quoter = _verifyRehypeDopplerHookMigratorDeployment(rehypeDopplerHookMigrator, migrator, poolManager);
+        _setConfigAddress(context, "rehype_doppler_hook_migrator", rehypeDopplerHookMigrator);
+        _setConfigAddress(context, "quoter", quoter);
+
+        if (alreadyDeployed) {
+            console.log("RehypeDopplerHookMigrator already deployed to:", rehypeDopplerHookMigrator);
+        } else {
+            console.log("RehypeDopplerHookMigrator deployed to:", rehypeDopplerHookMigrator);
+        }
+        console.log("RehypeDopplerHookMigrator quoter deployed to:", quoter);
+    }
+
+    function _verifyRehypeDopplerHookMigratorDeployment(
+        address addr,
+        address migrator,
+        address poolManager
+    ) internal view returns (address quoter) {
+        RehypeDopplerHookMigrator hook = RehypeDopplerHookMigrator(payable(addr));
+        require(address(hook.MIGRATOR()) == migrator, "RehypeDopplerHookMigrator migrator mismatch");
+        require(address(hook.poolManager()) == poolManager, "RehypeDopplerHookMigrator pool manager mismatch");
+
+        quoter = address(hook.quoter());
+        require(quoter != address(0) && quoter.code.length != 0, "RehypeDopplerHookMigrator quoter missing");
     }
 }
 
+contract DeployRehypeDopplerHookMigratorScript is DeployRehypeDopplerHookMigrator {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address rehypeDopplerHookMigrator) {
+        return _deployRehypeDopplerHookMigrator(_deployContext());
+    }
+}
+
+contract DeployRehypeDopplerHookMigratorScriptEthereum is DeployRehypeDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployRehypeDopplerHookMigratorScriptMonad is DeployRehypeDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployRehypeDopplerHookMigratorScriptBase is DeployRehypeDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployRehypeDopplerHookMigratorScriptBaseSepolia is DeployRehypeDopplerHookMigratorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
+    }
+}

--- a/script/deploy/DeployStreamableFeesLockerV2.s.sol
+++ b/script/deploy/DeployStreamableFeesLockerV2.s.sol
@@ -1,48 +1,91 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
 import { StreamableFeesLockerV2 } from "src/lockers/StreamableFeesLockerV2.sol";
 
-contract DeployStreamableFeesLockerV2Script is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployStreamableFeesLockerV2 is DeployBase {
+    function _deployStreamableFeesLockerV2(DeployContext memory context) internal returns (address lockerV2) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        return _deployStreamableFeesLockerV2(
+            context, poolManager, context.config.get(context.chainId, "airlock_multisig").toAddress()
+        );
+    }
 
-        uint256[] memory targets = new uint256[](4);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.MONAD_MAINNET;
+    function _deployStreamableFeesLockerV2(
+        DeployContext memory context,
+        address owner
+    ) internal returns (address lockerV2) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
+        return _deployStreamableFeesLockerV2(context, poolManager, owner);
+    }
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+    function _deployStreamableFeesLockerV2(
+        DeployContext memory context,
+        address poolManager,
+        address owner
+    ) internal returns (address lockerV2) {
+        bytes memory initCode =
+            abi.encodePacked(type(StreamableFeesLockerV2).creationCode, abi.encode(poolManager, owner));
+
+        bool alreadyDeployed;
+        (lockerV2, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(StreamableFeesLockerV2).name, STREAMABLE_FEES_LOCKER_VERSION, initCode
+        );
+
+        _verifyStreamableFeesLockerV2Deployment(lockerV2, poolManager, owner);
+        _setConfigAddress(context, "streamable_fees_locker_v2", lockerV2);
+
+        if (alreadyDeployed) {
+            console.log("StreamableFeesLockerV2 already deployed to:", lockerV2);
+        } else {
+            console.log("StreamableFeesLockerV2 deployed to:", lockerV2);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _verifyStreamableFeesLockerV2Deployment(address addr, address poolManager, address owner) internal view {
+        StreamableFeesLockerV2 locker = StreamableFeesLockerV2(payable(addr));
+        require(address(locker.poolManager()) == poolManager, "StreamableFeesLockerV2 pool manager mismatch");
+        require(locker.owner() == owner, "StreamableFeesLockerV2 owner mismatch");
+    }
+}
 
-        address createX = config.get("create_x").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
-        address owner = config.get("airlock_multisig").toAddress();
+contract DeployStreamableFeesLockerV2Script is DeployStreamableFeesLockerV2 {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, type(StreamableFeesLockerV2).name);
-        address deployedTo = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+    function run() public virtual {
+        deploy();
+    }
 
-        address lockerV2 = ICreateX(createX)
-            .deployCreate3(
-                salt, abi.encodePacked(type(StreamableFeesLockerV2).creationCode, abi.encode(poolManager, owner))
-            );
+    function deploy() public returns (address lockerV2) {
+        return _deployStreamableFeesLockerV2(_deployContext());
+    }
+}
 
-        require(lockerV2 == deployedTo, "Unexpected deployed address");
+contract DeployStreamableFeesLockerV2ScriptEthereum is DeployStreamableFeesLockerV2Script {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
 
-        vm.stopBroadcast();
-        config.set("streamable_fees_locker_v2", lockerV2);
+contract DeployStreamableFeesLockerV2ScriptMonad is DeployStreamableFeesLockerV2Script {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployStreamableFeesLockerV2ScriptBase is DeployStreamableFeesLockerV2Script {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployStreamableFeesLockerV2ScriptBaseSepolia is DeployStreamableFeesLockerV2Script {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeploySwapRestrictorDopplerHook.s.sol
+++ b/script/deploy/DeploySwapRestrictorDopplerHook.s.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
+import { ChainIds } from "script/utils/ChainIds.sol";
+import { SwapRestrictorDopplerHook } from "src/dopplerHooks/SwapRestrictorDopplerHook.sol";
+
+abstract contract DeploySwapRestrictorDopplerHook is DeployBase {
+    function _deploySwapRestrictorDopplerHook(DeployContext memory context)
+        internal
+        returns (address swapRestrictorDopplerHook)
+    {
+        address dopplerHookInitializer = context.config.get(context.chainId, "doppler_hook_initializer").toAddress();
+        return _deploySwapRestrictorDopplerHook(context, dopplerHookInitializer);
+    }
+
+    function _deploySwapRestrictorDopplerHook(
+        DeployContext memory context,
+        address dopplerHookInitializer
+    ) internal returns (address swapRestrictorDopplerHook) {
+        bytes memory initCode = abi.encodePacked(
+            type(SwapRestrictorDopplerHook).creationCode, abi.encode(dopplerHookInitializer)
+        );
+
+        bool alreadyDeployed;
+        (swapRestrictorDopplerHook, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(SwapRestrictorDopplerHook).name,
+            SWAP_RESTRICTOR_DOPPLER_HOOK_VERSION,
+            initCode
+        );
+
+        _verifySwapRestrictorDopplerHookDeployment(swapRestrictorDopplerHook, dopplerHookInitializer);
+        _setConfigAddress(context, "swap_restrictor_doppler_hook", swapRestrictorDopplerHook);
+
+        if (alreadyDeployed) {
+            console.log("SwapRestrictorDopplerHook already deployed to:", swapRestrictorDopplerHook);
+        } else {
+            console.log("SwapRestrictorDopplerHook deployed to:", swapRestrictorDopplerHook);
+        }
+    }
+
+    function _verifySwapRestrictorDopplerHookDeployment(address addr, address initializer) internal view {
+        require(SwapRestrictorDopplerHook(addr).INITIALIZER() == initializer, "SwapRestrictor initializer mismatch");
+    }
+}
+
+contract DeploySwapRestrictorDopplerHookScript is DeploySwapRestrictorDopplerHook {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address swapRestrictorDopplerHook) {
+        return _deploySwapRestrictorDopplerHook(_deployContext());
+    }
+}
+
+contract DeploySwapRestrictorDopplerHookScriptEthereum is DeploySwapRestrictorDopplerHookScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeploySwapRestrictorDopplerHookScriptMonad is DeploySwapRestrictorDopplerHookScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeploySwapRestrictorDopplerHookScriptBase is DeploySwapRestrictorDopplerHookScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeploySwapRestrictorDopplerHookScriptBaseSepolia is DeploySwapRestrictorDopplerHookScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
+    }
+}

--- a/script/deploy/DeployTopUpDistributor.s.sol
+++ b/script/deploy/DeployTopUpDistributor.s.sol
@@ -1,46 +1,77 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
 import { TopUpDistributor } from "src/TopUpDistributor.sol";
 
-contract DeployTopUpDistributorScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployTopUpDistributor is DeployBase {
+    function _deployTopUpDistributor(DeployContext memory context) internal returns (address topUpDistributor) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployTopUpDistributor(context, airlock);
+    }
 
-        uint256[] memory targets = new uint256[](5);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
-        targets[4] = ChainIds.MONAD_MAINNET;
+    function _deployTopUpDistributor(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address topUpDistributor) {
+        bytes memory initCode = abi.encodePacked(type(TopUpDistributor).creationCode, abi.encode(airlock));
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        bool alreadyDeployed;
+        (topUpDistributor, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(TopUpDistributor).name, TOP_UP_DISTRIBUTOR_VERSION, initCode
+        );
+
+        _verifyTopUpDistributorDeployment(topUpDistributor, airlock);
+        _setConfigAddress(context, "top_up_distributor", topUpDistributor);
+
+        if (alreadyDeployed) {
+            console.log("TopUpDistributor already deployed to:", topUpDistributor);
+        } else {
+            console.log("TopUpDistributor deployed to:", topUpDistributor);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _verifyTopUpDistributorDeployment(address addr, address airlock) internal view {
+        require(address(TopUpDistributor(payable(addr)).AIRLOCK()) == airlock, "TopUpDistributor airlock mismatch");
+    }
+}
 
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
+contract DeployTopUpDistributorScript is DeployTopUpDistributor {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, "TopUpDistributor-2");
-        address deployedTo = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+    function run() public virtual {
+        deploy();
+    }
 
-        address topUpDistributor = ICreateX(createX)
-            .deployCreate3(salt, abi.encodePacked(type(TopUpDistributor).creationCode, abi.encode(airlock)));
+    function deploy() public returns (address topUpDistributor) {
+        return _deployTopUpDistributor(_deployContext());
+    }
+}
 
-        require(topUpDistributor == deployedTo, "Unexpected deployed address");
+contract DeployTopUpDistributorScriptEthereum is DeployTopUpDistributorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
 
-        vm.stopBroadcast();
-        config.set("top_up_distributor", topUpDistributor);
+contract DeployTopUpDistributorScriptMonad is DeployTopUpDistributorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployTopUpDistributorScriptBase is DeployTopUpDistributorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployTopUpDistributorScriptBaseSepolia is DeployTopUpDistributorScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployUniV2MigratorSplit.s.sol
+++ b/script/deploy/DeployUniV2MigratorSplit.s.sol
@@ -1,74 +1,104 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { TypeKind, Variable } from "forge-std/LibVariable.sol";
-import { Script } from "forge-std/Script.sol";
-import { VmSafe } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
-import { LibString } from "solady/utils/LibString.sol";
-import { Airlock } from "src/Airlock.sol";
 import { UniswapV2MigratorSplit } from "src/migrators/UniswapV2MigratorSplit.sol";
 
-contract DeployUniV2MigratorSplitScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
-
-        uint256[] memory targets = new uint256[](4);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.MONAD_MAINNET;
-        targets[2] = ChainIds.BASE_MAINNET;
-        targets[3] = ChainIds.BASE_SEPOLIA;
-
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            vm.selectFork(forkOf[chainId]);
-            deployToChain(chainId);
-        }
+abstract contract DeployUniV2MigratorSplit is DeployBase {
+    function _deployUniV2MigratorSplit(DeployContext memory context) internal returns (address migrator) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        address topUpDistributor = context.config.get(context.chainId, "top_up_distributor").toAddress();
+        return _deployUniV2MigratorSplit(context, airlock, topUpDistributor);
     }
 
-    function deployToChain(uint256 chainId) internal {
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
-        address uniswapV2Factory = config.get("uniswap_v2_factory").toAddress();
-        address topUpDistributor = config.get("top_up_distributor").toAddress();
-        address weth = config.get("weth").toAddress();
+    function _deployUniV2MigratorSplit(
+        DeployContext memory context,
+        address airlock,
+        address topUpDistributor
+    ) internal returns (address migrator) {
+        address uniswapV2Factory = context.config.get(context.chainId, "uniswap_v2_factory").toAddress();
+        address weth = context.config.get(context.chainId, "weth").toAddress();
+        bytes memory initCode = abi.encodePacked(
+            type(UniswapV2MigratorSplit).creationCode, abi.encode(airlock, uniswapV2Factory, topUpDistributor, weth)
+        );
 
-        vm.startBroadcast();
-        bytes32 salt = generateCreate3Salt(msg.sender, type(UniswapV2MigratorSplit).name);
-        address deployedTo = computeCreate3Address(computeCreate3GuardedSalt(salt, msg.sender), createX);
+        bool alreadyDeployed;
+        (migrator, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context,
+            bytes32(0),
+            address(0),
+            type(UniswapV2MigratorSplit).name,
+            UNISWAP_V2_MIGRATOR_SPLIT_VERSION,
+            initCode
+        );
 
-        address migrator = ICreateX(createX)
-            .deployCreate3(
-                salt,
-                abi.encodePacked(
-                    type(UniswapV2MigratorSplit).creationCode,
-                    abi.encode(airlock, uniswapV2Factory, topUpDistributor, weth)
-                )
-            );
-        require(migrator == deployedTo, "Unexpected deployed address");
-        vm.stopBroadcast();
-        address locker = address(UniswapV2MigratorSplit(payable(migrator)).locker());
+        address locker =
+            _verifyUniV2MigratorSplitDeployment(migrator, airlock, uniswapV2Factory, topUpDistributor, weth);
+        _setConfigAddress(context, "uniswap_v2_migrator_split", migrator);
+        _setConfigAddress(context, "uniswap_v2_locker", locker);
 
-        // Only set the config if a broadcast has occurred
-        if (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)) {
-            config.set("uniswap_v2_migrator_split", migrator);
-            config.set("uniswap_v2_locker", locker);
+        if (alreadyDeployed) {
+            console.log("UniswapV2MigratorSplit already deployed to:", migrator);
+        } else {
+            console.log("UniswapV2MigratorSplit deployed to:", migrator);
         }
-        console.log(
-            "UniswapV2MigratorSplit was deployed to",
-            LibString.toHexString(uint256(uint160(migrator))),
-            "on chain ID",
-            LibString.toString(chainId)
-        );
-        console.log(
-            "UniswapV2Locker was deployed to",
-            LibString.toHexString(uint256(uint160(locker))),
-            "on chain ID",
-            LibString.toString(chainId)
-        );
+        console.log("UniswapV2Locker deployed to:", locker);
+    }
+
+    function _verifyUniV2MigratorSplitDeployment(
+        address addr,
+        address airlock,
+        address uniswapV2Factory,
+        address topUpDistributor,
+        address weth
+    ) internal view returns (address locker) {
+        UniswapV2MigratorSplit migrator = UniswapV2MigratorSplit(payable(addr));
+        require(address(migrator.airlock()) == airlock, "UniswapV2MigratorSplit airlock mismatch");
+        require(address(migrator.factory()) == uniswapV2Factory, "UniswapV2MigratorSplit factory mismatch");
+        require(address(migrator.TOP_UP_DISTRIBUTOR()) == topUpDistributor, "UniswapV2MigratorSplit top-up mismatch");
+        require(address(migrator.weth()) == weth, "UniswapV2MigratorSplit weth mismatch");
+
+        locker = address(migrator.locker());
+        require(locker != address(0) && locker.code.length != 0, "UniswapV2Locker missing");
+    }
+}
+
+contract DeployUniV2MigratorSplitScript is DeployUniV2MigratorSplit {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address migrator) {
+        return _deployUniV2MigratorSplit(_deployContext());
+    }
+}
+
+contract DeployUniV2MigratorSplitScriptEthereum is DeployUniV2MigratorSplitScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployUniV2MigratorSplitScriptMonad is DeployUniV2MigratorSplitScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployUniV2MigratorSplitScriptBase is DeployUniV2MigratorSplitScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployUniV2MigratorSplitScriptBaseSepolia is DeployUniV2MigratorSplitScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/deploy/DeployUniswapV4Initializer.s.sol
+++ b/script/deploy/DeployUniswapV4Initializer.s.sol
@@ -1,61 +1,115 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.24;
 
-import { IPoolManager } from "@v4-core/interfaces/IPoolManager.sol";
-import { ICreateX } from "createx/ICreateX.sol";
-import { Config } from "forge-std/Config.sol";
-import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "script/DeployBase.s.sol";
 import { ChainIds } from "script/utils/ChainIds.sol";
-import { computeCreate3Address, computeCreate3GuardedSalt, generateCreate3Salt } from "script/utils/CreateX.sol";
 import { DopplerDeployer, UniswapV4Initializer } from "src/initializers/UniswapV4Initializer.sol";
 
-contract DeployUniswapV4InitializerScript is Script, Config {
-    function run() public {
-        _loadConfigAndForks("./deployments.config.toml", true);
+abstract contract DeployUniswapV4Initializer is DeployBase {
+    function _deployUniswapV4Initializer(DeployContext memory context) internal returns (address uniswapV4Initializer) {
+        address airlock = context.config.get(context.chainId, "airlock").toAddress();
+        return _deployUniswapV4Initializer(context, airlock);
+    }
 
-        uint256[] memory targets = new uint256[](2);
-        targets[0] = ChainIds.ETH_MAINNET;
-        targets[1] = ChainIds.ETH_SEPOLIA;
+    function _deployUniswapV4Initializer(
+        DeployContext memory context,
+        address airlock
+    ) internal returns (address uniswapV4Initializer) {
+        address poolManager = context.config.get(context.chainId, "uniswap_v4_pool_manager").toAddress();
 
-        for (uint256 i; i < targets.length; i++) {
-            uint256 chainId = targets[i];
-            deployToChain(chainId);
+        address dopplerDeployer = _deployDopplerDeployer(context, poolManager);
+        bytes memory initCode = abi.encodePacked(
+            type(UniswapV4Initializer).creationCode, abi.encode(airlock, poolManager, dopplerDeployer)
+        );
+
+        bool alreadyDeployed;
+        (uniswapV4Initializer, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(UniswapV4Initializer).name, DYNAMIC_INITIALIZER_VERSION, initCode
+        );
+
+        _verifyUniswapV4InitializerDeployment(uniswapV4Initializer, airlock, poolManager, dopplerDeployer);
+        _setConfigAddress(context, "uniswap_v4_initializer", uniswapV4Initializer);
+
+        if (alreadyDeployed) {
+            console.log("UniswapV4Initializer already deployed to:", uniswapV4Initializer);
+        } else {
+            console.log("UniswapV4Initializer deployed to:", uniswapV4Initializer);
         }
     }
 
-    function deployToChain(uint256 chainId) internal {
-        vm.selectFork(forkOf[chainId]);
+    function _deployDopplerDeployer(
+        DeployContext memory context,
+        address poolManager
+    ) internal returns (address dopplerDeployer) {
+        bytes memory initCode = abi.encodePacked(type(DopplerDeployer).creationCode, abi.encode(poolManager));
 
-        address airlock = config.get("airlock").toAddress();
-        address createX = config.get("create_x").toAddress();
-        address poolManager = config.get("uniswap_v4_pool_manager").toAddress();
+        bool alreadyDeployed;
+        (dopplerDeployer, alreadyDeployed) = _deployOrUseExistingVersionedCreate3(
+            context, bytes32(0), address(0), type(DopplerDeployer).name, DYNAMIC_INITIALIZER_VERSION, initCode
+        );
 
-        vm.startBroadcast();
-        bytes32 dopplerDeployerSalt = generateCreate3Salt(msg.sender, type(DopplerDeployer).name);
-        address expectedDoppledDeployer =
-            computeCreate3Address(computeCreate3GuardedSalt(dopplerDeployerSalt, msg.sender), createX);
+        _verifyDopplerDeployerDeployment(dopplerDeployer, poolManager);
+        _setConfigAddress(context, "doppler_deployer", dopplerDeployer);
 
-        address dopplerDeployer = ICreateX(createX)
-            .deployCreate3(
-                dopplerDeployerSalt, abi.encodePacked(type(DopplerDeployer).creationCode, abi.encode(poolManager))
-            );
-        require(dopplerDeployer == expectedDoppledDeployer, "Unexpected DopplerDeployer address");
+        if (alreadyDeployed) {
+            console.log("DopplerDeployer already deployed to:", dopplerDeployer);
+        } else {
+            console.log("DopplerDeployer deployed to:", dopplerDeployer);
+        }
+    }
 
-        bytes32 uniswapV4InitializerSalt = generateCreate3Salt(msg.sender, type(UniswapV4Initializer).name);
-        address expectedUniswapV4Initializer =
-            computeCreate3Address(computeCreate3GuardedSalt(uniswapV4InitializerSalt, msg.sender), createX);
+    function _verifyDopplerDeployerDeployment(address addr, address poolManager) internal view {
+        require(address(DopplerDeployer(addr).poolManager()) == poolManager, "DopplerDeployer pool manager mismatch");
+    }
 
-        address uniswapV4Initializer = ICreateX(createX)
-            .deployCreate3(
-                uniswapV4InitializerSalt,
-                abi.encodePacked(
-                    type(UniswapV4Initializer).creationCode, abi.encode(airlock, poolManager, dopplerDeployer)
-                )
-            );
-        require(uniswapV4Initializer == expectedUniswapV4Initializer, "Unexpected UniswapV4Initializer address");
+    function _verifyUniswapV4InitializerDeployment(
+        address addr,
+        address airlock,
+        address poolManager,
+        address dopplerDeployer
+    ) internal view {
+        UniswapV4Initializer initializer = UniswapV4Initializer(addr);
+        require(address(initializer.airlock()) == airlock, "UniswapV4Initializer airlock mismatch");
+        require(address(initializer.poolManager()) == poolManager, "UniswapV4Initializer pool manager mismatch");
+        require(address(initializer.deployer()) == dopplerDeployer, "UniswapV4Initializer deployer mismatch");
+    }
+}
 
-        vm.stopBroadcast();
-        config.set("uniswap_v4_initializer", uniswapV4Initializer);
-        config.set("doppler_deployer", dopplerDeployer);
+contract DeployUniswapV4InitializerScript is DeployUniswapV4Initializer {
+    function setUp() public virtual {
+        _loadConfigForCurrentChain();
+    }
+
+    function run() public virtual {
+        deploy();
+    }
+
+    function deploy() public returns (address uniswapV4Initializer) {
+        return _deployUniswapV4Initializer(_deployContext());
+    }
+}
+
+contract DeployUniswapV4InitializerScriptEthereum is DeployUniswapV4InitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.ETH_MAINNET, false);
+    }
+}
+
+contract DeployUniswapV4InitializerScriptMonad is DeployUniswapV4InitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.MONAD_MAINNET, false);
+    }
+}
+
+contract DeployUniswapV4InitializerScriptBase is DeployUniswapV4InitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_MAINNET, false);
+    }
+}
+
+contract DeployUniswapV4InitializerScriptBaseSepolia is DeployUniswapV4InitializerScript {
+    function setUp() public override {
+        _loadConfigAndSelectFork(ChainIds.BASE_SEPOLIA, true);
     }
 }

--- a/script/utils/Versions.sol
+++ b/script/utils/Versions.sol
@@ -18,9 +18,9 @@ contract Versions {
     uint8 public constant LAUNCHPAD_GOVERNANCE_FACTORY_VERSION = 0;
     uint8 public constant NO_OP_GOVERNANCE_FACTORY_VERSION = 0;
     // --- Initializers ---
-    uint8 public constant STATIC_INITIALIZER_VERSION = 0;
-    uint8 public constant DYNAMIC_INITIALIZER_VERSION = 0;
-    uint8 public constant MULTICURVE_INITIALIZER_VERSION = 0;
+    uint8 public constant STATIC_INITIALIZER_VERSION = 0; // LockableUniswapV3Initializer
+    uint8 public constant DYNAMIC_INITIALIZER_VERSION = 0; // UniswapV4Initializer
+    uint8 public constant MULTICURVE_INITIALIZER_VERSION = 0; // DopplerHookInitializer
     // --- Migrators ---
     uint8 public constant DOPPLER_HOOK_MIGRATOR_VERSION = 0;
     uint8 public constant UNISWAP_V2_MIGRATOR_SPLIT_VERSION = 0;


### PR DESCRIPTION
## Description

This PR overhauls Doppler’s deployment script infrastructure by making `script/DeployDoppler.s.sol` the supported aggregate deployment entry point, normalizing individual deploy scripts around shared deployment helpers, and adding a manual GitHub Actions workflow for simulation, broadcast, artifact upload, and deployment-record PR creation.

## Motivation

These changes make deployments safer and more repeatable across supported chains. The previous scripts used inconsistent execution patterns, chain targeting, deterministic address handling, config writes, and verification. The new structure centralizes those concerns so deployments can be rerun, version-bumped, validated, and documented more reliably.

## Changes

- Added `.github/workflows/deploy-contracts.yml` to trigger deployments with simulate/broadcast modes.
- Added `docs/Deployment.md` and updated `README.md` to document the supported deployment flow.
- Expanded `script/DeployBase.s.sol` with shared deploy context, CREATE2 bootstrap validation, CREATE3 protocol deployment validation, versioned deployment helpers, existing-deployment reuse, broadcast-sender resolution, testnet checks, and broadcast-only config writes.
- Updated `DeployDopplerCreateXDeployerScript` to bootstrap `DopplerCreateXDeployer` through CreateX CREATE2, locking the expected address to the exact deployer init code while keeping the bootstrap deployment permissionless.
- Completed `script/DeployDoppler.s.sol` as the aggregate deployer for core contracts, factories, initializers, hooks, migrators, quoters, and bundler.
- Refactored `script/deploy/*.s.sol` into reusable deploy helpers plus standalone and chain-specific script wrappers.
- Added deployment support for `SwapRestrictorDopplerHook`.
- Preserved prior deploy scripts under `legacy/script/deploy`.
- Clarified initializer version constants in `script/utils/Versions.sol`.