### PR TITLE
fix: rehype fees

### DIFF
--- a/script/utils/Versions.sol
+++ b/script/utils/Versions.sol
@@ -27,7 +27,7 @@ contract Versions {
     uint8 public constant NO_OP_MIGRATOR_VERSION = 0;
     // --- Doppler Hooks ---
     uint8 public constant REHYPE_DOPPLER_HOOK_INITIALIZER_VERSION = 2;
-    uint8 public constant REHYPE_DOPPLER_HOOK_MIGRATOR_VERSION = 0;
+    uint8 public constant REHYPE_DOPPLER_HOOK_MIGRATOR_VERSION = 1;
     uint8 public constant SWAP_RESTRICTOR_DOPPLER_HOOK_VERSION = 0;
     // --- Other ---
     uint8 public constant DOPPLER_LENS_QUOTER_VERSION = 0;

--- a/snapshots/Multicurve.json
+++ b/snapshots/Multicurve.json
@@ -1,5 +1,5 @@
 {
-  "adjustCurves": "5822",
+  "adjustCurves": "5810",
   "calculateLogNormalDistribution": "32404",
-  "calculatePositions": "355594"
+  "calculatePositions": "355592"
 }

--- a/src/dopplerHooks/RehypeDopplerHookInitializer.sol
+++ b/src/dopplerHooks/RehypeDopplerHookInitializer.sol
@@ -41,6 +41,7 @@ import {
     MAX_SWAP_FEE,
     PoolAlreadyInitialized,
     PoolInfo,
+    SWAP_FEE_DENOMINATOR,
     SenderNotAirlockOwner,
     SwapSimulation
 } from "src/types/RehypeTypes.sol";
@@ -835,7 +836,7 @@ contract RehypeDopplerHookInitializer is BaseDopplerHookInitializer, FeesManager
         }
 
         uint24 currentFee = _getCurrentFee(poolId);
-        uint256 feeAmount = FullMath.mulDiv(feeBase, currentFee, MAX_SWAP_FEE);
+        uint256 feeAmount = FullMath.mulDiv(feeBase, currentFee, SWAP_FEE_DENOMINATOR);
         uint256 balanceOfFeeCurrency = feeCurrency.balanceOf(address(poolManager));
 
         if (balanceOfFeeCurrency < feeAmount) {

--- a/src/dopplerHooks/RehypeDopplerHookMigrator.sol
+++ b/src/dopplerHooks/RehypeDopplerHookMigrator.sol
@@ -27,9 +27,9 @@ import {
     HookFees,
     InsufficientFeeCurrency,
     MAX_REBALANCE_ITERATIONS,
-    MAX_SWAP_FEE,
     MigratorInitData,
     PoolInfo,
+    SWAP_FEE_DENOMINATOR,
     SenderNotAirlockOwner,
     SenderNotAuthorized,
     SwapSimulation
@@ -739,7 +739,7 @@ contract RehypeDopplerHookMigrator is BaseDopplerHookMigrator, ReentrancyGuard {
             feeBase = uint256(-inputAmount);
         }
 
-        uint256 feeAmount = FullMath.mulDiv(feeBase, getHookFees[poolId].customFee, MAX_SWAP_FEE);
+        uint256 feeAmount = FullMath.mulDiv(feeBase, getHookFees[poolId].customFee, SWAP_FEE_DENOMINATOR);
         uint256 balanceOfFeeCurrency = feeCurrency.balanceOf(address(poolManager));
 
         if (balanceOfFeeCurrency < feeAmount) {

--- a/src/types/RehypeTypes.sol
+++ b/src/types/RehypeTypes.sol
@@ -42,8 +42,11 @@ event AirlockOwnerFeesClaimed(PoolId indexed poolId, address indexed airlockOwne
 event FeeBeneficiariesSet(PoolId indexed poolId, BeneficiaryData[] beneficiaries);
 
 // Constants
-/// @dev Maximum swap fee denominator (1e6 = 100%)
+/// @dev Maximum swap fee (1e6 = 100%)
 uint256 constant MAX_SWAP_FEE = 0.8e6;
+
+/// @dev Swap fee denominator (1e6 = 100%)
+uint256 constant SWAP_FEE_DENOMINATOR = 1e6;
 
 /// @dev Epsilon trigger for rebalancing swaps
 uint128 constant EPSILON = 1e6;

--- a/test/integration/RehypeDopplerHookInitializer.t.sol
+++ b/test/integration/RehypeDopplerHookInitializer.t.sol
@@ -43,7 +43,7 @@ import {
     FeeSchedule,
     InitData as RehypeInitData,
     InsufficientFeeCurrency,
-    MAX_SWAP_FEE,
+    SWAP_FEE_DENOMINATOR,
     SenderNotAirlockOwner
 } from "src/types/RehypeTypes.sol";
 import { WAD } from "src/types/Wad.sol";
@@ -715,7 +715,7 @@ contract RehypeDopplerHookIntegrationTest is Deployers {
         feeBeneficiaries[0] = BeneficiaryData({ beneficiary: feeBeneficiary, shares: uint96(0.95e18) });
         feeBeneficiaries[1] = BeneficiaryData({ beneficiary: airlockOwner, shares: uint96(0.05e18) });
 
-        uint24 rehypeFeeRate = 12_000; // 12_000 / MAX_SWAP_FEE = 1.5%
+        uint24 rehypeFeeRate = 12_000; // 12_000 / SWAP_FEE_DENOMINATOR = 1.2%
         (bool isToken0, address asset) = _createTokenWithConfig(
             bytes32(uint256(73)),
             rehypeFeeRate,
@@ -1777,7 +1777,7 @@ contract RehypeDopplerHookIntegrationTest is Deployers {
     }
 
     function _grossFeeFromNetOutput(uint256 netOutput, uint24 feeRate) internal pure returns (uint256) {
-        return netOutput * feeRate / (MAX_SWAP_FEE - feeRate);
+        return netOutput * feeRate / (SWAP_FEE_DENOMINATOR - feeRate);
     }
 
     function _executeBeneficiaryFeeCycle(

--- a/test/unit/dopplerHooks/rehypeHookInitializer/RehypeDopplerHookInitializer.t.sol
+++ b/test/unit/dopplerHooks/rehypeHookInitializer/RehypeDopplerHookInitializer.t.sol
@@ -36,7 +36,8 @@ import {
     InvalidFeeRange,
     MAX_SWAP_FEE,
     PoolAlreadyInitialized,
-    PoolInfo
+    PoolInfo,
+    SWAP_FEE_DENOMINATOR
 } from "src/types/RehypeTypes.sol";
 import { WAD } from "src/types/Wad.sol";
 
@@ -1333,7 +1334,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
             IPoolManager.SwapParams({ zeroForOne: true, amountSpecified: -1 ether, sqrtPriceLimitX96: 0 });
         int128 amount0 = -int128(uint128(1 ether));
         int128 amount1 = int128(uint128(5 ether));
-        uint256 expectedFeeAmount = 5 ether * 10_000 / MAX_SWAP_FEE;
+        uint256 expectedFeeAmount = 5 ether * 10_000 / SWAP_FEE_DENOMINATOR;
 
         vm.prank(address(initializer));
         (Currency feeCurrency, int128 hookDelta) =
@@ -1384,7 +1385,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
             IPoolManager.SwapParams({ zeroForOne: true, amountSpecified: 0.5 ether, sqrtPriceLimitX96: 0 });
         int128 amount0 = -int128(uint128(12 ether / 10));
         int128 amount1 = int128(uint128(0.5 ether));
-        uint256 expectedFeeAmount = (12 ether / 10) * 10_000 / MAX_SWAP_FEE;
+        uint256 expectedFeeAmount = (12 ether / 10) * 10_000 / SWAP_FEE_DENOMINATOR;
 
         vm.prank(address(initializer));
         (Currency feeCurrency, int128 hookDelta) =
@@ -1416,7 +1417,8 @@ contract RehypeDopplerHookInitializerTest is Deployers {
     }
 
     function test_collectSwapFees_GrossOwnerCarveOutAcrossModesDirectionsAndBeneficiaryConfigurations() public {
-        uint256 expectedGross = 2_000_019;
+        uint256 feeBase = 160_001_520;
+        uint256 expectedGross = feeBase * 10_000 / SWAP_FEE_DENOMINATOR;
         uint256 expectedOwnerCut = expectedGross * AIRLOCK_OWNER_FEE_BPS / BPS_DENOMINATOR;
         uint256 caseIndex;
 
@@ -1424,7 +1426,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
             for (uint256 exactMode; exactMode < 2; ++exactMode) {
                 for (uint256 direction; direction < 2; ++direction) {
                     (uint256 grossFee, uint256 ownerCut) = _assertGrossOwnerCarveOut(
-                        caseIndex++, exactMode == 0, direction == 0, beneficiaryConfiguration == 1, 160_001_520
+                        caseIndex++, exactMode == 0, direction == 0, beneficiaryConfiguration == 1, feeBase
                     );
 
                     assertEq(grossFee, expectedGross, "gross must be calculated from the swap delta");
@@ -1438,7 +1440,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
         feeBase = bound(feeBase, 80, 1e30);
 
         (uint256 grossFee, uint256 ownerCut) = _assertGrossOwnerCarveOut(20, true, true, false, feeBase);
-        uint256 expectedGross = feeBase * 10_000 / MAX_SWAP_FEE;
+        uint256 expectedGross = feeBase * 10_000 / SWAP_FEE_DENOMINATOR;
         uint256 expectedOwnerCut = expectedGross * AIRLOCK_OWNER_FEE_BPS / BPS_DENOMINATOR;
 
         assertEq(grossFee, expectedGross, "gross must be derived from output delta");
@@ -1446,9 +1448,14 @@ contract RehypeDopplerHookInitializerTest is Deployers {
     }
 
     function test_collectSwapFees_TinyGrossFloorsOwnerCutToZero() public {
-        (uint256 grossFee, uint256 ownerCut) = _assertGrossOwnerCarveOut(21, false, false, true, 1599);
+        uint256 feeBase = 1599;
+        (uint256 grossFee, uint256 ownerCut) = _assertGrossOwnerCarveOut(21, false, false, true, feeBase);
 
-        assertEq(grossFee, 19, "gross fee must floor independently before the owner carve-out");
+        assertEq(
+            grossFee,
+            feeBase * 10_000 / SWAP_FEE_DENOMINATOR,
+            "gross fee must floor independently before the owner carve-out"
+        );
         assertEq(ownerCut, 0, "a sub-twenty-wei gross fee must floor the five-percent owner cut to zero");
     }
 
@@ -1535,7 +1542,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
             IPoolManager.SwapParams({ zeroForOne: true, amountSpecified: -1 ether, sqrtPriceLimitX96: 0 });
         int128 amount0 = -int128(uint128(1 ether));
         int128 amount1 = int128(uint128(5 ether));
-        uint256 expectedFeeAmount = 5 ether * 6000 / MAX_SWAP_FEE;
+        uint256 expectedFeeAmount = 5 ether * 6000 / SWAP_FEE_DENOMINATOR;
 
         vm.prank(address(initializer));
         (Currency feeCurrency, int128 hookDelta) =
@@ -1757,7 +1764,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
         (Currency feeCurrency, int128 hookDelta) =
             trackingHarness.exposed_collectSwapFees(params, delta, poolKey, poolKey.toId());
 
-        grossFee = feeBase * 10_000 / MAX_SWAP_FEE;
+        grossFee = feeBase * 10_000 / SWAP_FEE_DENOMINATOR;
         ownerCut = grossFee * AIRLOCK_OWNER_FEE_BPS / BPS_DENOMINATOR;
         uint256 routingAmount = grossFee - ownerCut;
         bool feeInCurrency0 = zeroForOne != exactInput;
@@ -1795,7 +1802,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
         trackingHarness.onInitialization(address(token0), poolKey, abi.encode(initData));
 
         uint256 feeBase = 160_001_520;
-        uint256 grossFee = feeBase * 10_000 / MAX_SWAP_FEE;
+        uint256 grossFee = feeBase * 10_000 / SWAP_FEE_DENOMINATOR;
         ownerCut = grossFee * AIRLOCK_OWNER_FEE_BPS / BPS_DENOMINATOR;
         uint256 routingAmount = grossFee - ownerCut;
         uint256 recipientBalanceBefore = token1.balanceOf(buybackDst);
@@ -2000,7 +2007,7 @@ contract RehypeDopplerHookInitializerTest is Deployers {
     }
 
     function _nonzeroLpExpectation(uint256 feeBase) internal pure returns (NonzeroLpAccounting memory expected) {
-        expected.gross = feeBase * 10_000 / MAX_SWAP_FEE;
+        expected.gross = feeBase * 10_000 / SWAP_FEE_DENOMINATOR;
         expected.owner = expected.gross * 500 / 10_000;
         expected.postOwner = expected.gross - expected.owner;
 

--- a/test/unit/dopplerHooks/rehypeHookMigrator/RehypeDopplerHookMigrator.t.sol
+++ b/test/unit/dopplerHooks/rehypeHookMigrator/RehypeDopplerHookMigrator.t.sol
@@ -13,6 +13,8 @@ import { SenderNotMigrator } from "src/base/BaseDopplerHookMigrator.sol";
 import { RehypeDopplerHookMigrator } from "src/dopplerHooks/RehypeDopplerHookMigrator.sol";
 import { DopplerHookMigrator } from "src/migrators/DopplerHookMigrator.sol";
 import {
+    AIRLOCK_OWNER_FEE_BPS,
+    BPS_DENOMINATOR,
     FeeDistributionInfo,
     FeeDistributionMustAddUpToWAD,
     FeeRoutingMode,
@@ -20,6 +22,7 @@ import {
     InsufficientFeeCurrency,
     MigratorInitData,
     PoolInfo,
+    SWAP_FEE_DENOMINATOR,
     SenderNotAirlockOwner,
     SenderNotAuthorized
 } from "src/types/RehypeTypes.sol";
@@ -27,6 +30,26 @@ import { WAD } from "src/types/Wad.sol";
 
 contract MockPoolManager {
     // Minimal mock - just needs to exist for the quoter constructor
+}
+
+contract MigratorTrackingPoolManager {
+    Currency public lastTakeCurrency;
+    address public lastTakeRecipient;
+    uint256 public lastTakeAmount;
+    uint256 public takeCallCount;
+    uint160 internal constant MOCK_SQRT_PRICE_X96 = uint160(1 << 96);
+
+    function take(Currency currency, address to, uint256 amount) external {
+        lastTakeCurrency = currency;
+        lastTakeRecipient = to;
+        lastTakeAmount = amount;
+        ++takeCallCount;
+        TestERC20(Currency.unwrap(currency)).transfer(to, amount);
+    }
+
+    function extsload(bytes32) external pure returns (bytes32 value) {
+        return bytes32(uint256(MOCK_SQRT_PRICE_X96));
+    }
 }
 
 contract MockAirlockForMigrator {
@@ -761,59 +784,133 @@ contract RehypeDopplerHookMigratorTest is Test {
     }
 
     /* ----------------------------------------------------------------------------- */
-    /*                  onAfterSwap fee accumulation (no PoolManager)                */
+    /*                          onAfterSwap fee accounting                           */
     /* ----------------------------------------------------------------------------- */
 
-    function test_onAfterSwap_AccumulatesFees(PoolKey memory poolKey) public {
-        poolKey.tickSpacing = 60;
+    function test_onAfterSwap_ExactInputChargesConfiguredFeeAndConservesAccounting() public {
+        _assertOnAfterSwapFeeAccounting(true);
+    }
 
-        address asset = Currency.unwrap(poolKey.currency0);
-        address numeraire = Currency.unwrap(poolKey.currency1);
-        address buybackDst = makeAddr("buybackDst");
-        uint24 customFee = 10_000; // 1%
-
-        // All fees go to beneficiary for simple testing
-        bytes memory data = abi.encode(
-            MigratorInitData({
-                numeraire: numeraire,
-                buybackDst: buybackDst,
-                customFee: customFee,
-                feeRoutingMode: FeeRoutingMode.DirectBuyback,
-                feeDistributionInfo: FeeDistributionInfo({
-                    assetFeesToAssetBuybackWad: 0,
-                    assetFeesToNumeraireBuybackWad: 0,
-                    assetFeesToBeneficiaryWad: WAD,
-                    assetFeesToLpWad: 0,
-                    numeraireFeesToAssetBuybackWad: 0,
-                    numeraireFeesToNumeraireBuybackWad: 0,
-                    numeraireFeesToBeneficiaryWad: WAD,
-                    numeraireFeesToLpWad: 0
-                })
-            })
-        );
-
-        vm.prank(address(mockMigrator));
-        rehypeHookMigrator.onInitialization(asset, poolKey, data);
-
-        // Simulate a swap with amountSpecified < 0 (exact input) and zeroForOne = true
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({ zeroForOne: true, amountSpecified: -1e18, sqrtPriceLimitX96: 0 });
-
-        vm.prank(address(mockMigrator));
-        rehypeHookMigrator.onAfterSwap(
-            address(0x123), poolKey, swapParams, BalanceDeltaLibrary.ZERO_DELTA, new bytes(0)
-        );
-
-        PoolId poolId = poolKey.toId();
-
-        // Verify customFee was stored correctly
-        (,,,,,, uint24 storedFee) = rehypeHookMigrator.getHookFees(poolId);
-        assertEq(storedFee, customFee);
+    function test_onAfterSwap_ExactOutputChargesConfiguredInputFeeAndConservesAccounting() public {
+        _assertOnAfterSwapFeeAccounting(false);
     }
 
     /* ----------------------------------------------------------------------------- */
     /*                              Helpers                                          */
     /* ----------------------------------------------------------------------------- */
+
+    function _assertOnAfterSwapFeeAccounting(bool exactInput) internal {
+        (
+            RehypeDopplerHookMigrator hook,
+            MigratorTrackingPoolManager trackingPoolManager,
+            TestERC20 token0,
+            TestERC20 token1,
+            PoolKey memory poolKey
+        ) = _trackingFeeSetup();
+
+        uint256 feeBase = exactInput ? 5 ether : 12 ether / 10;
+        int128 inputAmount = exactInput ? int128(1 ether) : int128(uint128(feeBase));
+        int128 outputAmount = exactInput ? int128(uint128(feeBase)) : int128(0.5 ether);
+        uint256 expectedFee = feeBase * 10_000 / SWAP_FEE_DENOMINATOR;
+        uint256 expectedOwnerFee = expectedFee * AIRLOCK_OWNER_FEE_BPS / BPS_DENOMINATOR;
+        TestERC20 feeToken = exactInput ? token1 : token0;
+        TestERC20 oppositeToken = exactInput ? token0 : token1;
+
+        vm.prank(address(mockMigrator));
+        (Currency feeCurrency, int128 hookDelta) = hook.onAfterSwap(
+            address(0x1234),
+            poolKey,
+            IPoolManager.SwapParams({
+                zeroForOne: true,
+                amountSpecified: exactInput ? -int256(1 ether) : int256(0.5 ether),
+                sqrtPriceLimitX96: 0
+            }),
+            toBalanceDelta(-inputAmount, outputAmount),
+            ""
+        );
+
+        assertEq(Currency.unwrap(feeCurrency), address(feeToken));
+        assertEq(uint256(uint128(hookDelta)), expectedFee);
+        assertEq(trackingPoolManager.takeCallCount(), 1);
+        assertEq(Currency.unwrap(trackingPoolManager.lastTakeCurrency()), address(feeToken));
+        assertEq(trackingPoolManager.lastTakeRecipient(), address(hook));
+        assertEq(trackingPoolManager.lastTakeAmount(), expectedFee);
+        assertEq(feeToken.balanceOf(address(hook)), expectedFee);
+        assertEq(oppositeToken.balanceOf(address(hook)), 0);
+
+        (
+            uint128 fees0,
+            uint128 fees1,
+            uint128 beneficiaryFees0,
+            uint128 beneficiaryFees1,
+            uint128 ownerFees0,
+            uint128 ownerFees1,
+        ) = hook.getHookFees(poolKey.toId());
+        assertEq(fees0, 0);
+        assertEq(fees1, 0);
+        uint256 beneficiaryFee = exactInput ? beneficiaryFees1 : beneficiaryFees0;
+        uint256 ownerFee = exactInput ? ownerFees1 : ownerFees0;
+        assertEq(beneficiaryFee, expectedFee - expectedOwnerFee);
+        assertEq(ownerFee, expectedOwnerFee);
+        assertEq(beneficiaryFee + ownerFee, expectedFee);
+        assertEq(exactInput ? beneficiaryFees0 + ownerFees0 : beneficiaryFees1 + ownerFees1, 0);
+    }
+
+    function _trackingFeeSetup()
+        internal
+        returns (
+            RehypeDopplerHookMigrator hook,
+            MigratorTrackingPoolManager trackingPoolManager,
+            TestERC20 token0,
+            TestERC20 token1,
+            PoolKey memory poolKey
+        )
+    {
+        trackingPoolManager = new MigratorTrackingPoolManager();
+        hook = new RehypeDopplerHookMigrator(
+            DopplerHookMigrator(payable(address(mockMigrator))), IPoolManager(address(trackingPoolManager))
+        );
+        token0 = new TestERC20(type(uint128).max);
+        token1 = new TestERC20(type(uint128).max);
+        poolKey = PoolKey({
+            currency0: Currency.wrap(address(token0)),
+            currency1: Currency.wrap(address(token1)),
+            fee: 0,
+            tickSpacing: 60,
+            hooks: IHooks(address(0))
+        });
+
+        token0.transfer(address(trackingPoolManager), 10 ether);
+        token1.transfer(address(trackingPoolManager), 10 ether);
+
+        vm.prank(address(mockMigrator));
+        hook.onInitialization(
+            address(token0), poolKey, abi.encode(_beneficiaryOnlyMigratorInitData(address(token1), address(0), 10_000))
+        );
+    }
+
+    function _beneficiaryOnlyMigratorInitData(
+        address numeraire,
+        address buybackDst,
+        uint24 customFee
+    ) internal pure returns (MigratorInitData memory) {
+        return MigratorInitData({
+            numeraire: numeraire,
+            buybackDst: buybackDst,
+            customFee: customFee,
+            feeRoutingMode: FeeRoutingMode.DirectBuyback,
+            feeDistributionInfo: FeeDistributionInfo({
+                assetFeesToAssetBuybackWad: 0,
+                assetFeesToNumeraireBuybackWad: 0,
+                assetFeesToBeneficiaryWad: WAD,
+                assetFeesToLpWad: 0,
+                numeraireFeesToAssetBuybackWad: 0,
+                numeraireFeesToNumeraireBuybackWad: 0,
+                numeraireFeesToBeneficiaryWad: WAD,
+                numeraireFeesToLpWad: 0
+            })
+        });
+    }
 
     function _quarterMigratorInitData(
         address numeraire,


### PR DESCRIPTION
## Description

Corrects rehype swap-fee calculations so configured fee rates use the standard `1e6` percentage denominator. This ensures a configured fee of `10_000` charges 1% rather than 1.25%.

## Motivation

`MAX_SWAP_FEE` represents the maximum permitted fee of 80%, but it was incorrectly reused as the fee-calculation denominator. Dividing by `800_000` instead of `1_000_000` inflated configured rehype fees by 25% and could charge 100% at the maximum configured rate.

Separating the validation cap from the percentage denominator restores the intended fee rates while preserving the existing 80% maximum.

## Changes

- Added `SWAP_FEE_DENOMINATOR = 1e6` while retaining `MAX_SWAP_FEE = 0.8e6` as the validation cap.
- Updated fee calculations in:
  - `RehypeDopplerHookInitializer`
  - `RehypeDopplerHookMigrator`
- Updated integration and unit-test expectations to use the correct denominator.
- Expanded migrator coverage for exact-input and exact-output swaps, including:
  - Correct fee currency and amount
  - Pool manager transfers
  - Beneficiary and Airlock owner allocation
  - Conservation of total fee accounting
- Bumped `REHYPE_DOPPLER_HOOK_MIGRATOR_VERSION` from `0` to `1`.
- Refreshed the Multicurve gas snapshot.