### PR TITLE
fix(ci): preserve Solana deployment addresses

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -57,12 +57,19 @@ jobs:
             exit 1
           fi
 
+          if [[ ! -f docs/snippets/solana-deployments.md ]]; then
+            echo "Expected docs/snippets/solana-deployments.md to exist"
+            exit 1
+          fi
+
           if [[ ! -d docs/reference ]]; then
             echo "Expected docs/reference directory to exist in docs repo checkout"
             exit 1
           fi
 
           cp contracts/Deployments.md docs/reference/contract-addresses.md
+          printf '\n' >> docs/reference/contract-addresses.md
+          cat docs/snippets/solana-deployments.md >> docs/reference/contract-addresses.md
 
       - name: Commit and push to the docs repository
         run: |


### PR DESCRIPTION
Prevents the deployment housekeeping workflow from deleting the Solana program tables whenever EVM deployment documentation is regenerated.

After copying the generated EVM `Deployments.md`, the workflow now requires and appends the docs-owned `snippets/solana-deployments.md` fragment. This keeps EVM generation authoritative for EVM addresses without allowing it to overwrite the separately maintained Solana rows.

Depends on whetstoneresearch/doppler-docs#35, which restores the eight removed addresses and adds the persistent fragment. Merge that PR first.

Validation: the restored docs page suffix matches the fragment byte-for-byte, and `git diff --check` passes in both repositories.
